### PR TITLE
Fix recharge confirmation dialog being closed before click

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -71,6 +71,7 @@ window.__ModuleLoader__.load({
       var notifiedRef = React.useRef(false)
       var chipRef = React.useRef(null)
       var panelRef = React.useRef(null)
+      var confirmRef = React.useRef(null)
       var [alignLeft, setAlignLeft] = React.useState(false)
       var [data, setData] = React.useState(null)
       var [open, setOpen] = React.useState(false)
@@ -148,6 +149,7 @@ window.__ModuleLoader__.load({
           var t = event.target
           if (chipRef.current && chipRef.current.contains(t)) return
           if (panelRef.current && panelRef.current.contains(t)) return
+          if (confirmRef.current && confirmRef.current.contains(t)) return
           setOpen(false)
         }
         document.addEventListener('mousedown', onDocDown)
@@ -290,7 +292,19 @@ window.__ModuleLoader__.load({
         }
       }, chipTextParts)
 
-      if (!open && !floated) return chip
+      var confirmOverlay = null
+      if (confirming) {
+        confirmOverlay = React.createElement('div', { ref: confirmRef, className: 'dshw_overlay', onClick: function () { setConfirming(false) } },
+          React.createElement('div', { className: 'dshw_overlayBox', onClick: function (e) { e.stopPropagation() } },
+            React.createElement('div', null, '\u5c06\u6253\u5f00 DeepSeek \u5f00\u653e\u5e73\u53f0\u5b98\u65b9\u5145\u503c\u9875\uff1a'),
+            React.createElement('div', { className: 'dshw_muted' }, 'https://platform.deepseek.com/top_up'),
+            React.createElement('div', null, '\u767b\u5f55\u4e0e\u652f\u4ed8\u7531\u5b98\u65b9\u9875\u9762\u5b8c\u6210\uff0c\u672c\u63d2\u4ef6\u4e0d\u63a5\u89e6\u8d26\u53f7\u4e0e\u652f\u4ed8\u4fe1\u606f\u3002'),
+            React.createElement('div', { className: 'dshw_overlayRow' },
+              React.createElement('button', { className: 'dshw_btn', onClick: function () { setConfirming(false) } }, '\u53d6\u6d88'),
+              React.createElement('button', { className: 'dshw_btn dshw_btnPrimary', onClick: goRecharge }, '\u53bb\u5145\u503c'))))
+      }
+
+      if (!open && !floated) return React.createElement(React.Fragment, null, chip, confirmOverlay)
 
       var balanceRows = []
       if (bal.available && bal.balances && bal.balances.length > 0) {
@@ -371,18 +385,6 @@ window.__ModuleLoader__.load({
           }
         }, '\u6e05\u9664\u672c\u4f1a\u8bdd\u6570\u636e')
       )
-
-      var confirmOverlay = null
-      if (confirming) {
-        confirmOverlay = React.createElement('div', { className: 'dshw_overlay', onClick: function () { setConfirming(false) } },
-          React.createElement('div', { className: 'dshw_overlayBox', onClick: function (e) { e.stopPropagation() } },
-            React.createElement('div', null, '\u5c06\u6253\u5f00 DeepSeek \u5f00\u653e\u5e73\u53f0\u5b98\u65b9\u5145\u503c\u9875\uff1a'),
-            React.createElement('div', { className: 'dshw_muted' }, 'https://platform.deepseek.com/top_up'),
-            React.createElement('div', null, '\u767b\u5f55\u4e0e\u652f\u4ed8\u7531\u5b98\u65b9\u9875\u9762\u5b8c\u6210\uff0c\u672c\u63d2\u4ef6\u4e0d\u63a5\u89e6\u8d26\u53f7\u4e0e\u652f\u4ed8\u4fe1\u606f\u3002'),
-            React.createElement('div', { className: 'dshw_overlayRow' },
-              React.createElement('button', { className: 'dshw_btn', onClick: function () { setConfirming(false) } }, '\u53d6\u6d88'),
-              React.createElement('button', { className: 'dshw_btn dshw_btnPrimary', onClick: goRecharge }, '\u53bb\u5145\u503c'))))
-      }
 
       if (floated) {
         if (minimized) {


### PR DESCRIPTION
## Problem

`v0.1.2` recharge flow is broken in the Web UI: after the anti-phishing confirmation dialog appears, clicking **去充值** closes the dialog and does not open the official top-up page. Additionally, the very first click on the chip's **↗充** link produces no visible reaction at all.

Reproduced on DSH `0.1.0-rc.6` (web profile, macOS, Firefox 144 via Playwright).

## Root cause

Two client-side ordering/ownership bugs in `lib/client.js`:

1. **Confirmation button unmounts itself before `click` completes.**
   The panel's outside-close handler runs on `mousedown`:

   ```js
   function onDocDown(event) {
     var t = event.target
     if (chipRef.current && chipRef.current.contains(t)) return
     if (panelRef.current && panelRef.current.contains(t)) return
     setOpen(false)
   }
   ```

   The confirmation overlay is not inside `panelRef`, so `mousedown` on the **去充值** button calls `setOpen(false)`. React unmounts the overlay before the `click` event reaches the button, so `goRecharge`/`window.open` never run.

2. **Overlay is created after the closed-chip early return.**

   ```js
   if (!open && !floated) return chip
   ...
   var confirmOverlay = null
   if (confirming) { confirmOverlay = ... }
   ```

   With the chip closed, `onRechargeClick` sets `confirming = true`, but the component returns before rendering the overlay — first click appears to do nothing.

## Fix

- Track the overlay with a `confirmRef` and ignore `mousedown` inside it in the outside-close handler.
- Build `confirmOverlay` before the closed-state early return so it renders in every state (`chip`, panel, floated, minimized dot).

## Validation

- `node --check index.js`
- `node --check lib/client.js`
- `node -e "JSON.parse(require('node:fs').readFileSync('package.json','utf8'))"`
- `node --test` — 12/12 passed
- Playwright + Firefox end-to-end regression (fresh profile):
  - closed chip → click `↗充` → confirmation dialog appears ✅
  - open panel → click `↗ 去官方充值` → click `去充值` → new tab opens `platform.deepseek.com/top_up` (test profile not signed in, so observed URL is the `sign_in` redirect) ✅
