### PR TITLE
release: v0.1.3 reliability and UI fixes

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,15 +9,25 @@ permissions:
 
 jobs:
   validate:
-    runs-on: ubuntu-latest
+    name: Node ${{ matrix.node }} · ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        node: [22.19.0, 24]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: ${{ matrix.node }}
       - name: Validate package metadata
         run: node -e "JSON.parse(require('node:fs').readFileSync('package.json', 'utf8'))"
       - name: Check host syntax
         run: node --check index.js
       - name: Check browser syntax
         run: node --check lib/client.js
+      - name: Run regression tests
+        run: npm test
+      - name: Verify publishable package
+        run: npm pack --dry-run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project are documented here.
 
+## 0.1.3 - 2026-08-16
+
+- Fixed the recharge shortcut so its first click reliably opens the anti-phishing confirmation, including when the detail panel is closed (contributed in PR #2 by QZYWQ).
+- Fixed the detail panel opening below the viewport; it now uses viewport-aware fixed positioning and flips above the chip when needed.
+- Session cost is now accumulated at the price active when each usage event arrives, so historical spend no longer changes at peak/off-peak or policy boundaries. Existing stores migrate once to schema v2 and keep the migrated estimate.
+- Added currency-aware balance formatting and stopped applying the CNY low-balance threshold to non-CNY accounts.
+- Reworked floating drag with pointer events for mouse and touch, fixed click-without-drag crashes, and clamp positions using the actual dot/window dimensions.
+- Replaced nested clickable markup with native buttons, added dialog semantics, focus handling, Escape support, and keyboard focus styles.
+- Moved the interactive chip to the Harness `conversation.input.left` slot, deduplicated concurrent balance refreshes, and flush pending persisted changes during plugin shutdown.
+- Expanded regression coverage and CI to run tests and package verification on Linux and Windows with Node 22 and 24.
+
 ## 0.1.2 - 2026-08-15
 
 - Fixed the client bundle loader id to match the package name (`deepseek-harness-wallet`); 0.1.1 still registered the old `dsh-wallet` id, which aborted the whole plugin boot ("loaded without registering") after the rename. Regression test added.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 </p>
 
 <p align="center">
-  <img alt="Version 0.1.2" src="https://img.shields.io/badge/version-0.1.2-5965d8">
+  <img alt="Version 0.1.3" src="https://img.shields.io/badge/version-0.1.3-5965d8">
   <img alt="DeepSeek Harness rc.6" src="https://img.shields.io/badge/dsh-0.1.0--rc.6-4aa3ff">
   <img alt="MIT License" src="https://img.shields.io/badge/license-MIT-3b7a57">
 </p>
@@ -24,12 +24,12 @@ A resident one-line chip beside the composer: official DeepSeek (balance, sessio
 ## What it shows
 
 ```
-余额 5.89 · 本场 0.72 · 官 18.8M | 三方 800K · ↗充
+余额 ¥5.89 · 本场 ¥0.72 · 官 18.8M | 三方 800K · ↗充
 ```
 
-- **Official DeepSeek** — live balance (60s global refresh with fast boot retries), current-session cost (official pricing timeline, including the 2026-08-17 peak/off-peak rollout), and token breakdown.
+- **Official DeepSeek** — live balance (60s global refresh with fast boot retries), current-session cost locked to the price active for each usage event (including the 2026-08-17 peak/off-peak rollout), and token breakdown.
 - **Third-party total** — current-session tokens (input / cache read / output). No balance guessing, no cost math, zero configuration.
-- **Click the chip** to open the detail panel: per-currency balance breakdown, cost and token splits, a freely editable low-balance threshold in CNY (two decimals, persisted globally; the chip compares the CNY balance, never a mixed-currency sum), manual refresh, and a jump to the official recharge page (first click shows the domain for confirmation — anti-phishing).
+- **Click the chip** to open the detail panel: correctly formatted per-currency balances, cost and token splits, a freely editable low-balance threshold in CNY (two decimals, persisted globally; alerts only compare a CNY balance and never mix currencies), manual refresh, and a jump to the official recharge page (first click shows the domain for confirmation — anti-phishing).
 - **Floating window mode** — from the detail panel, detach the wallet into a floating window you can drag anywhere (position remembered across reloads), or minimize it to a small dot; the dot turns red below the threshold.
 - **Low-balance alert** — below the threshold the chip turns red with a breathing animation and fires one desktop notification; it resets automatically once the balance recovers.
 - **Theme-native UI** — built entirely on `--dsw-alias-*` theme variables, so light and dark themes both render correctly; the panel closes when you click outside and flips open-direction near screen edges.
@@ -75,7 +75,7 @@ dsh plugin --profile web remove deepseek-harness-wallet
 
 | Item | Behavior |
 | --- | --- |
-| Token accounting | Listens to the `llm/stream` event and buckets per provider (`deepseek-official` vs. everything else) and per session; multiple sessions never mix accounts. |
+| Token accounting | Listens to the `llm/stream` event and buckets per provider (`deepseek-official` vs. everything else) and per session; each usage event also locks its contemporaneous official price, so multiple sessions and pricing windows never mix. |
 | Balance | The `DEEPSEEK_API_KEY` from the credentials seam never leaves this machine except as the `Authorization` header of the official `/user/balance` request. |
 | Session log | The plugin writes no events; its data lives in `$DSH_HOME/storages/wallet.json`. |
 | Model surface | No tools registered, no prompt injection, zero token cost. |
@@ -91,7 +91,7 @@ CNY per 1M tokens, curated from official announcements (cache writes are not bil
   - v4-flash (off-peak / peak): cache read 0.05 / 0.10, input 1.5 / 3, output 4.5 / 9
   - v4-pro (off-peak / peak): cache read 0.15 / 0.30, input 4.5 / 9, output 13.5 / 27
 
-deepseek-chat and deepseek-reasoner keep their flat rates. Costs are estimates; the API-returned balance is authoritative.
+deepseek-chat and deepseek-reasoner keep their flat rates. Each usage event is priced when it arrives; upgrading from 0.1.2 migrates legacy counters once using the then-current rate. Costs are estimates; the API-returned balance is authoritative.
 
 ## Roadmap
 

--- a/docs/i18n/README.zh-CN.md
+++ b/docs/i18n/README.zh-CN.md
@@ -8,7 +8,7 @@
 </p>
 
 <p align="center">
-  <img alt="版本 0.1.2" src="https://img.shields.io/badge/version-0.1.2-5965d8">
+  <img alt="版本 0.1.3" src="https://img.shields.io/badge/version-0.1.3-5965d8">
   <img alt="DeepSeek Harness rc.6" src="https://img.shields.io/badge/dsh-0.1.0--rc.6-4aa3ff">
   <img alt="MIT License" src="https://img.shields.io/badge/license-MIT-3b7a57">
 </p>
@@ -24,12 +24,12 @@
 ## 显示什么
 
 ```
-余额 5.89 · 本场 0.72 · 官 18.8M | 三方 800K · ↗充
+余额 ¥5.89 · 本场 ¥0.72 · 官 18.8M | 三方 800K · ↗充
 ```
 
-- **官方 DeepSeek**——余额（60 秒全局刷新 + 启动快速重试）、本会话花费（官方价格时间线计价，含 2026-08-17 峰谷价）、token 拆分。
+- **官方 DeepSeek**——余额（60 秒全局刷新 + 启动快速重试）、本会话花费（每次用量按发生时价格锁定，含 2026-08-17 峰谷价）、token 拆分。
 - **第三方合计**——本会话 token（输入 / 缓存读 / 输出）。不算钱、不猜余额、零配置。
-- **点开面板**——币种余额拆分、花费与 token 明细、可自由填写的低余额阈值（人民币、两位小数、全局持久化；标签始终用人民币余额对比，绝不混币种相加）、手动刷新、跳转官方充值页（首次点击显示域名确认，防钓鱼）。
+- **点开面板**——按币种正确显示符号的余额拆分、花费与 token 明细、可自由填写的低余额阈值（人民币、两位小数、全局持久化；仅在有人民币余额时提醒，绝不跨币种比较或相加）、手动刷新、跳转官方充值页（首次点击显示域名确认，防钓鱼）。
 - **悬浮窗口**——从面板切出可自由拖动的悬浮钱包窗口（位置跨刷新记忆），或最小化为小圆点；低于阈值时圆点变红。
 - **低余额提醒**——低于阈值时标签变红呼吸 + 桌面通知一次，余额回升后自动复位。
 - **跟随主题**——全部使用 `--dsw-alias-*` 主题变量，浅色/深色主题自动适配；面板点外部自动关闭，靠边自动反向展开。
@@ -75,7 +75,7 @@ dsh plugin --profile web remove deepseek-harness-wallet
 
 | 项目 | 行为 |
 | --- | --- |
-| Token 计费 | 监听 `llm/stream` 事件，按 provider 分桶（`deepseek-official` 之外全部归第三方）、按会话隔离，多开会话互不串账。 |
+| Token 计费 | 监听 `llm/stream` 事件，按 provider 分桶（`deepseek-official` 之外全部归第三方）、按会话隔离；每次用量同时锁定当时的官方价格，会话与峰谷时段都不串账。 |
 | 余额 | 凭证库 `DEEPSEEK_API_KEY` 只在本机流转，仅作为 `Authorization` 头发往官方 `/user/balance` 接口。 |
 | 会话日志 | 插件不写入任何事件；数据存于 `$DSH_HOME/storages/wallet.json`。 |
 | 模型可见性 | 不注册工具、不注入提示词、零 token 消耗。 |
@@ -91,7 +91,7 @@ CNY/百万 token，整理自官方公告（缓存写入不计费）：
   - v4-flash（空闲 / 高峰）：缓存读 0.05 / 0.10、输入 1.5 / 3、输出 4.5 / 9
   - v4-pro（空闲 / 高峰）：缓存读 0.15 / 0.30、输入 4.5 / 9、输出 13.5 / 27
 
-deepseek-chat 与 deepseek-reasoner 维持固定价格。花费为估算值，以官方接口返回的余额为准。
+deepseek-chat 与 deepseek-reasoner 维持固定价格。每次用量在到达时计价；从 0.1.2 升级时，旧 token 记录会按升级时价格做一次迁移，此后不再随时段变化。花费为估算值，以官方接口返回的余额为准。
 
 ## Roadmap
 

--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ const RECHARGE_URL = 'https://platform.deepseek.com/top_up'
 const STORE_PATH = join(process.env.DSH_HOME ?? join(homedir(), '.dsh'), 'storages', 'wallet.json')
 const DEFAULT_THRESHOLD = 5
 const BALANCE_REFRESH_MS = 60_000
+const STORE_VERSION = 2
 
 // Beijing (UTC+8, no DST) peak windows: 09:00-12:00 and 14:00-18:00.
 const BEIJING_OFFSET_MS = 8 * 3600_000
@@ -75,9 +76,10 @@ export function ratesFor(model, atMs) {
 export function costOf(model, usage, atMs) {
   const rates = ratesFor(model, atMs)
   if (rates === null) return null
-  const input = (usage.inputTokens ?? usage.input ?? 0) * rates.input
-  const cacheRead = (usage.cacheReadTokens ?? usage.cacheRead ?? 0) * rates.cacheHit
-  const output = (usage.outputTokens ?? usage.output ?? 0) * rates.output
+  usage = usage !== null && typeof usage === 'object' ? usage : {}
+  const input = finiteCounter(usage.inputTokens ?? usage.input) * rates.input
+  const cacheRead = finiteCounter(usage.cacheReadTokens ?? usage.cacheRead) * rates.cacheHit
+  const output = finiteCounter(usage.outputTokens ?? usage.output) * rates.output
   return (input + cacheRead + output) / 1e6
 }
 
@@ -85,7 +87,8 @@ function emptyCounters() {
   return { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, reasoning: 0 }
 }
 
-function emptyBucket() {
+function emptyBucket(priced) {
+  if (priced === true) return { models: {}, cost: 0, priced: true }
   return { models: {} }
 }
 
@@ -95,47 +98,109 @@ export function normalizeThreshold(value) {
   return Math.min(100000, Math.max(0, Math.round(parsed * 100) / 100))
 }
 
+function finiteCounter(value) {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : 0
+}
+
+function normalizeCounters(value) {
+  const source = value !== null && typeof value === 'object' && !Array.isArray(value) ? value : {}
+  return {
+    input: finiteCounter(source.input),
+    output: finiteCounter(source.output),
+    cacheRead: finiteCounter(source.cacheRead),
+    cacheWrite: finiteCounter(source.cacheWrite),
+    reasoning: finiteCounter(source.reasoning),
+  }
+}
+
+function normalizeModels(value) {
+  const source = value !== null && typeof value === 'object' && !Array.isArray(value) ? value : {}
+  const models = {}
+  for (const [model, counters] of Object.entries(source)) {
+    if (model === '__proto__' || model === 'prototype' || model === 'constructor') continue
+    models[model] = normalizeCounters(counters)
+  }
+  return models
+}
+
+function migratedOfficialBucket(value, atMs) {
+  const source = value !== null && typeof value === 'object' && !Array.isArray(value) ? value : {}
+  const models = normalizeModels(source.models)
+  if (typeof source.cost === 'number' && Number.isFinite(source.cost) && source.cost >= 0 && typeof source.priced === 'boolean') {
+    return { models, cost: source.cost, priced: source.priced }
+  }
+  let cost = 0
+  let priced = true
+  for (const [model, counters] of Object.entries(models)) {
+    const valueAtMigration = costOf(model, counters, atMs)
+    if (valueAtMigration === null) priced = false
+    else cost += valueAtMigration
+  }
+  return { models, cost, priced }
+}
+
+export function normalizeStoreData(value, atMs = Date.now()) {
+  const source = value !== null && typeof value === 'object' && !Array.isArray(value) ? value : {}
+  const rawSessions = source.sessions !== null && typeof source.sessions === 'object' && !Array.isArray(source.sessions)
+    ? source.sessions
+    : {}
+  const sessions = {}
+  for (const [sessionId, value] of Object.entries(rawSessions)) {
+    if (sessionId === '__proto__' || sessionId === 'prototype' || sessionId === 'constructor') continue
+    const rawSession = value !== null && typeof value === 'object' && !Array.isArray(value) ? value : {}
+    sessions[sessionId] = {
+      official: migratedOfficialBucket(rawSession.official, atMs),
+      third: { models: normalizeModels(rawSession.third && rawSession.third.models) },
+    }
+  }
+  const normalized = { version: STORE_VERSION, threshold: normalizeThreshold(source.threshold), sessions }
+  return { store: normalized, migrated: JSON.stringify(source) !== JSON.stringify(normalized) }
+}
+
 function loadStore() {
   try {
-    const parsed = JSON.parse(readFileSync(STORE_PATH, 'utf8'))
-    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
-      return { threshold: DEFAULT_THRESHOLD, sessions: {} }
-    }
-    const sessions = parsed.sessions !== null && typeof parsed.sessions === 'object' && !Array.isArray(parsed.sessions)
-      ? parsed.sessions
-      : {}
-    return { threshold: normalizeThreshold(parsed.threshold), sessions }
+    return normalizeStoreData(JSON.parse(readFileSync(STORE_PATH, 'utf8')))
   } catch {
-    return { threshold: DEFAULT_THRESHOLD, sessions: {} }
+    return {
+      store: { version: STORE_VERSION, threshold: DEFAULT_THRESHOLD, sessions: {} },
+      migrated: false,
+    }
   }
 }
 
 let saveTimer = null
-let store = loadStore()
+const loadedStore = loadStore()
+let store = loadedStore.store
+let storeNeedsSave = loadedStore.migrated
+
+function persistStore(logger) {
+  if (saveTimer !== null) {
+    clearTimeout(saveTimer)
+    saveTimer = null
+  }
+  try {
+    mkdirSync(dirname(STORE_PATH), { recursive: true })
+    const tmp = STORE_PATH + '.tmp'
+    writeFileSync(tmp, JSON.stringify(store))
+    renameSync(tmp, STORE_PATH)
+  } catch (error) {
+    if (logger && typeof logger.warn === 'function') {
+      logger.warn('dsh-wallet: failed to persist store: ' + String(error))
+    }
+  }
+}
 
 function scheduleSave(logger) {
   if (saveTimer !== null) return
-  saveTimer = setTimeout(() => {
-    saveTimer = null
-    try {
-      mkdirSync(dirname(STORE_PATH), { recursive: true })
-      const tmp = STORE_PATH + '.tmp'
-      writeFileSync(tmp, JSON.stringify(store))
-      renameSync(tmp, STORE_PATH)
-    } catch (error) {
-      if (logger && typeof logger.warn === 'function') {
-        logger.warn('dsh-wallet: failed to persist store: ' + String(error))
-      }
-    }
-  }, 500)
+  saveTimer = setTimeout(() => persistStore(logger), 500)
 }
 
 function addUsage(counters, usage) {
-  counters.input += usage.inputTokens ?? 0
-  counters.output += usage.outputTokens ?? 0
-  counters.cacheRead += usage.cacheReadTokens ?? 0
-  counters.cacheWrite += usage.cacheWriteTokens ?? 0
-  counters.reasoning += usage.reasoningTokens ?? 0
+  counters.input += finiteCounter(usage.inputTokens)
+  counters.output += finiteCounter(usage.outputTokens)
+  counters.cacheRead += finiteCounter(usage.cacheReadTokens)
+  counters.cacheWrite += finiteCounter(usage.cacheWriteTokens)
+  counters.reasoning += finiteCounter(usage.reasoningTokens)
 }
 
 function bucketTotals(bucket) {
@@ -150,25 +215,37 @@ function bucketTotals(bucket) {
   return totals
 }
 
-function recordUsage(options, usage) {
+export function addOfficialUsage(bucket, model, usage, atMs) {
+  if (!Object.hasOwn(bucket.models, model)) bucket.models[model] = emptyCounters()
+  addUsage(bucket.models[model], usage)
+  const cost = costOf(model, usage, atMs)
+  if (cost === null) bucket.priced = false
+  else bucket.cost += cost
+}
+
+function recordUsage(options, usage, atMs = Date.now()) {
   const sessionId = options.sessionId
   const provider = options.provider
   const model = options.model ?? options.modelName ?? ''
-  if (sessionId === undefined || provider === undefined || provider === '') return
-  if (store.sessions[sessionId] === undefined) {
-    store.sessions[sessionId] = { official: emptyBucket(), third: emptyBucket() }
+  if (typeof sessionId !== 'string' || sessionId === '' || typeof provider !== 'string' || provider === '') return
+  if (typeof model !== 'string' || model === '__proto__' || model === 'prototype' || model === 'constructor') return
+  if (sessionId === '__proto__' || sessionId === 'prototype' || sessionId === 'constructor') return
+  if (!Object.hasOwn(store.sessions, sessionId)) {
+    store.sessions[sessionId] = { official: emptyBucket(true), third: emptyBucket(false) }
   }
   const session = store.sessions[sessionId]
   const bucket = provider === OFFICIAL_PROVIDER ? session.official : session.third
-  if (bucket.models[model] === undefined) {
-    bucket.models[model] = emptyCounters()
+  if (provider === OFFICIAL_PROVIDER) addOfficialUsage(bucket, model, usage, atMs)
+  else {
+    if (!Object.hasOwn(bucket.models, model)) bucket.models[model] = emptyCounters()
+    addUsage(bucket.models[model], usage)
   }
-  addUsage(bucket.models[model], usage)
 }
 
 let balance = { fetchedAt: 0, available: false, balances: [], error: null }
+let balanceRefresh = null
 
-async function refreshBalance(ctx) {
+async function performBalanceRefresh(ctx) {
   const credentials = ctx.get('credentials')
   if (credentials === undefined) {
     balance = { fetchedAt: Date.now(), available: false, balances: [], error: 'no credentials service' }
@@ -210,6 +287,14 @@ async function refreshBalance(ctx) {
   }
 }
 
+function refreshBalance(ctx) {
+  if (balanceRefresh !== null) return balanceRefresh
+  balanceRefresh = performBalanceRefresh(ctx).finally(() => {
+    balanceRefresh = null
+  })
+  return balanceRefresh
+}
+
 export function sumBalances(infos) {
   if (!Array.isArray(infos) || infos.length === 0) return 0
   // The chip and the threshold are denominated in CNY: prefer the CNY record
@@ -235,6 +320,14 @@ export function sumBalances(infos) {
   return total
 }
 
+export function balanceCurrency(infos) {
+  if (!Array.isArray(infos)) return null
+  const cny = infos.find((info) => info.currency === 'CNY' && Number.isFinite(Number.parseFloat(info.total_balance)))
+  if (cny !== undefined) return 'CNY'
+  const firstFinite = infos.find((info) => Number.isFinite(Number.parseFloat(info.total_balance)))
+  return firstFinite && typeof firstFinite.currency === 'string' ? firstFinite.currency.toUpperCase() : null
+}
+
 function balanceTotal() {
   return sumBalances(balance.balances)
 }
@@ -245,21 +338,18 @@ function sessionView(sessionId) {
   if (session === undefined) return { official: null, third: null }
   const official = bucketTotals(session.official)
   const third = bucketTotals(session.third)
-  const now = Date.now()
-  let cost = 0
-  let priced = true
-  for (const model of Object.keys(session.official.models)) {
-    const value = costOf(model, session.official.models[model], now)
-    if (value === null) priced = false
-    else cost += value
-  }
   return {
-    official: { tokens: official, cost: priced ? cost : null, models: session.official.models },
+    official: {
+      tokens: official,
+      cost: session.official.priced === true ? session.official.cost : null,
+      models: session.official.models,
+    },
     third: { tokens: third, models: session.third.models },
   }
 }
 
 function snapshotView(sessionId, threshold) {
+  const currency = balanceCurrency(balance.balances)
   return {
     ok: true,
     balance: {
@@ -267,17 +357,23 @@ function snapshotView(sessionId, threshold) {
       fetchedAt: balance.fetchedAt,
       balances: balance.balances,
       total: balance.available ? balanceTotal() : null,
+      currency,
       error: balance.available ? null : balance.error,
     },
     session: sessionView(sessionId),
     threshold,
-    lowBalance: balance.available && threshold > 0 && balanceTotal() < threshold,
+    // The configured threshold is CNY-denominated; do not compare unlike
+    // currencies for international accounts that do not expose a CNY row.
+    lowBalance: balance.available && currency === 'CNY' && threshold > 0 && balanceTotal() < threshold,
     rechargeUrl: RECHARGE_URL,
   }
 }
 
 function json(res, status, body) {
-  res.writeHead(status, { 'content-type': 'application/json; charset=utf-8' })
+  res.writeHead(status, {
+    'content-type': 'application/json; charset=utf-8',
+    'cache-control': 'no-store',
+  })
   res.end(JSON.stringify(body))
 }
 
@@ -285,12 +381,15 @@ function readBody(req, cap) {
   cap = cap || 4096
   return new Promise((resolve) => {
     let size = 0
+    let tooLarge = false
     const parts = []
     req.on('data', (chunk) => {
       size += chunk.length
       if (size <= cap) parts.push(chunk)
+      else tooLarge = true
     })
     req.on('end', () => {
+      if (tooLarge) return resolve(null)
       try {
         resolve(JSON.parse(Buffer.concat(parts).toString('utf8') || '{}'))
       } catch {
@@ -311,6 +410,10 @@ function sessionParam(req) {
 
 export function apply(ctx, config) {
   config = config || {}
+  if (storeNeedsSave) {
+    storeNeedsSave = false
+    scheduleSave(ctx.logger)
+  }
   // Threshold lives ONLY in the persisted store; an explicit row config may
   // still override it for power users, but the bundle patch sets none.
   let threshold = store.threshold
@@ -324,16 +427,18 @@ export function apply(ctx, config) {
     const downstream = next()
     return (async function* () {
       let usage = null
+      let usageAt = 0
       try {
         for await (const chunk of downstream) {
           if (chunk !== null && chunk !== undefined && chunk.type === 'usage' && chunk.usage !== undefined) {
             usage = chunk.usage
+            usageAt = Date.now()
           }
           yield chunk
         }
       } finally {
         if (usage !== null) {
-          recordUsage(options, usage)
+          recordUsage(options, usage, usageAt)
           scheduleSave(ctx.logger)
         }
       }
@@ -412,8 +517,7 @@ export function apply(ctx, config) {
       disposeRefresh()
       disposeClear()
       clearInterval(balanceTimer)
-      clearTimeout(saveTimer)
-      saveTimer = null
+      if (saveTimer !== null) persistStore(ctx.logger)
     }
   }, 'dsh-wallet: routes')
 }

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,4 +1,4 @@
-/* deepseek-harness-wallet client half: the composer-dock chip.
+/* deepseek-harness-wallet client half: the composer input wallet chip.
  * Loaded through the client module loader (CJS wrapper). The loader id MUST
  * equal the package name: client-modules verifies the boot graph row id
  * (the package name) against the id registered via __ModuleLoader__.load. */
@@ -9,27 +9,32 @@ window.__ModuleLoader__.load({
     var exports = module.exports
     Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' })
     var React = require('react')
+    var useLayoutEffect = React.useLayoutEffect || React.useEffect
 
     var POLL_MS = 15000
     var CONFIRM_KEY = 'dsh-wallet-recharge-confirmed'
 
     var css = [
-      '.dshw_chip{border:1px solid var(--dsw-alias-border-l2,rgba(0,0,0,.15));background:transparent;height:22px;color:var(--dsw-alias-label-primary,#1f2328);cursor:pointer;white-space:nowrap;border-radius:999px;align-items:center;gap:6px;padding:0 8px;font-size:12px;line-height:1;display:inline-flex;position:relative}',
-      '.dshw_chip:hover{border-color:var(--dsw-alias-brand-primary,#4aa3ff)}',
+      '.dshw_chip{border:1px solid var(--dsw-alias-border-l2,rgba(0,0,0,.15));background:transparent;height:22px;color:var(--dsw-alias-label-primary,#1f2328);white-space:nowrap;border-radius:999px;align-items:stretch;font-size:12px;line-height:1;display:inline-flex;position:relative}',
+      '.dshw_chip:hover,.dshw_chip:focus-within{border-color:var(--dsw-alias-brand-primary,#4aa3ff)}',
       '.dshw_chipLow{border-color:var(--dsw-alias-state-error-primary,#e5534b);color:var(--dsw-alias-state-error-primary,#e5534b);animation:dshwPulse 1.8s infinite}',
       '@keyframes dshwPulse{0%,100%{box-shadow:0 0 0 0 rgba(229,83,75,.45)}50%{box-shadow:0 0 0 5px rgba(229,83,75,0)}}',
       '.dshw_sep{opacity:.45}',
-      '.dshw_recharge{color:var(--dsw-alias-brand-primary,#4aa3ff);text-decoration:none;border-left:1px solid var(--dsw-alias-border-l2,rgba(0,0,0,.15));padding-left:6px}',
-      '.dshw_panel{z-index:40;border:1px solid var(--dsw-alias-border-l2,rgba(0,0,0,.15));background:var(--dsw-alias-bg-overlay,#ffffff);min-width:240px;max-width:300px;color:var(--dsw-alias-label-primary,#1f2328);border-radius:8px;flex-direction:column;gap:6px;padding:10px 12px;font-size:12px;display:flex;position:absolute;top:calc(100% + 6px);right:0;box-shadow:0 4px 12px #0000004d}',
+      '.dshw_chipMain,.dshw_recharge{border:0;background:transparent;color:inherit;font:inherit;cursor:pointer;align-items:center;display:inline-flex;gap:6px;margin:0}',
+      '.dshw_chipMain{padding:0 7px;border-radius:999px 0 0 999px}',
+      '.dshw_recharge{color:var(--dsw-alias-brand-primary,#4aa3ff);border-left:1px solid var(--dsw-alias-border-l2,rgba(0,0,0,.15));padding:0 7px 0 6px;border-radius:0 999px 999px 0}',
+      '.dshw_chipMain:focus-visible,.dshw_recharge:focus-visible,.dshw_btn:focus-visible,.dshw_floatBtn:focus-visible,.dshw_dot:focus-visible{outline:2px solid var(--dsw-alias-brand-primary,#4aa3ff);outline-offset:2px}',
+      '.dshw_panel{z-index:40;border:1px solid var(--dsw-alias-border-l2,rgba(0,0,0,.15));background:var(--dsw-alias-bg-overlay,#ffffff);box-sizing:border-box;width:min(300px,calc(100vw - 16px));max-height:calc(100vh - 16px);overflow:auto;color:var(--dsw-alias-label-primary,#1f2328);border-radius:8px;flex-direction:column;gap:6px;padding:10px 12px;font-size:12px;display:flex;position:fixed;box-shadow:0 4px 12px #0000004d}',
       '.dshw_row{justify-content:space-between;align-items:center;gap:10px;display:flex}',
+      '.dshw_row>span:last-child{text-align:right;overflow-wrap:anywhere}',
       '.dshw_title{font-weight:600;opacity:.9}',
       '.dshw_muted{color:var(--dsw-alias-label-tertiary,#6b7280)}',
       '.dshw_divider{border-top:1px solid var(--dsw-alias-border-l2,rgba(0,0,0,.12));margin-top:2px;padding-top:6px}',
       '.dshw_input{background:var(--dsw-alias-bg-layer-1,#ffffff);border:1px solid var(--dsw-alias-border-l2,rgba(0,0,0,.15));color:var(--dsw-alias-label-primary,#1f2328);border-radius:5px;padding:3px 6px;width:56px;font-size:12px}',
       '.dshw_btn{border:1px solid var(--dsw-alias-border-l2,rgba(0,0,0,.15));background:transparent;color:var(--dsw-alias-label-primary,#1f2328);border-radius:5px;padding:3px 8px;font-size:12px;cursor:pointer}',
       '.dshw_btnPrimary{background:var(--dsw-alias-brand-primary,#4aa3ff);border-color:transparent;color:var(--dsw-alias-label-primary-foreground,#ffffff)}',
-      '.dshw_overlay{position:fixed;inset:0;background:var(--dsw-alias-bg-mask-drop,rgba(0,0,0,.55));display:flex;align-items:center;justify-content:center;z-index:60}',
-      '.dshw_overlayBox{background:var(--dsw-alias-bg-overlay,#ffffff);border:1px solid var(--dsw-alias-border-l2,rgba(0,0,0,.15));color:var(--dsw-alias-label-primary,#1f2328);border-radius:8px;padding:14px 18px;max-width:320px;font-size:13px;line-height:1.7}',
+      '.dshw_overlay{position:fixed;inset:0;background:var(--dsw-alias-bg-mask-drop,rgba(0,0,0,.55));display:flex;align-items:center;justify-content:center;z-index:100}',
+      '.dshw_overlayBox{background:var(--dsw-alias-bg-overlay,#ffffff);border:1px solid var(--dsw-alias-border-l2,rgba(0,0,0,.15));color:var(--dsw-alias-label-primary,#1f2328);border-radius:8px;padding:14px 18px;width:min(320px,calc(100vw - 32px));box-sizing:border-box;font-size:13px;line-height:1.7}',
       '.dshw_overlayRow{margin-top:10px;display:flex;gap:8px;justify-content:flex-end}',
 
       '.dshw_float{position:fixed;z-index:80;min-width:230px;max-width:280px;border:1px solid var(--dsw-alias-border-l2,rgba(0,0,0,.15));background:var(--dsw-alias-bg-overlay,#fff);color:var(--dsw-alias-label-primary,#1f2328);border-radius:12px;box-shadow:0 6px 20px rgba(0,0,0,.18);display:flex;flex-direction:column;gap:6px;padding:10px 12px;font-size:12px;user-select:none}',
@@ -54,9 +59,35 @@ window.__ModuleLoader__.load({
       return String(n)
     }
 
-    function fmtMoney(n) {
-      if (n === null || n === undefined || Number.isNaN(n)) return '--'
-      return n.toFixed(2)
+    function fmtCurrency(value, currency) {
+      var number = typeof value === 'number' ? value : Number.parseFloat(value)
+      if (!Number.isFinite(number)) return '--'
+      var code = typeof currency === 'string' && /^[A-Z]{3}$/.test(currency.toUpperCase()) ? currency.toUpperCase() : 'CNY'
+      try {
+        return new Intl.NumberFormat(undefined, {
+          style: 'currency', currency: code, currencyDisplay: 'narrowSymbol',
+          minimumFractionDigits: 2, maximumFractionDigits: 2
+        }).format(number)
+      } catch (e) {
+        return code + ' ' + number.toFixed(2)
+      }
+    }
+
+    function computePanelPosition(chipRect, panelRect, viewportWidth, viewportHeight) {
+      var margin = 8
+      var gap = 6
+      var left = Math.max(margin, Math.min(chipRect.left, viewportWidth - panelRect.width - margin))
+      var below = chipRect.bottom + gap
+      var above = chipRect.top - panelRect.height - gap
+      var top = below + panelRect.height <= viewportHeight - margin ? below : Math.max(margin, above)
+      return { left: left, top: top, visibility: 'visible' }
+    }
+
+    function clampPosition(pos, width, height, viewportWidth, viewportHeight) {
+      return {
+        x: Math.max(4, Math.min(viewportWidth - width - 4, pos.x)),
+        y: Math.max(4, Math.min(viewportHeight - height - 4, pos.y))
+      }
     }
 
     function totalTokens(counters) {
@@ -70,11 +101,16 @@ window.__ModuleLoader__.load({
       var dataRef = React.useRef(null)
       var notifiedRef = React.useRef(false)
       var chipRef = React.useRef(null)
+      var chipButtonRef = React.useRef(null)
       var panelRef = React.useRef(null)
       var confirmRef = React.useRef(null)
-      var [alignLeft, setAlignLeft] = React.useState(false)
+      var cancelButtonRef = React.useRef(null)
+      var confirmButtonRef = React.useRef(null)
+      var restoreFocusRef = React.useRef(null)
+      var thresholdInitializedRef = React.useRef(false)
       var [data, setData] = React.useState(null)
       var [open, setOpen] = React.useState(false)
+      var [panelStyle, setPanelStyle] = React.useState({ visibility: 'hidden' })
       var [thresholdDraft, setThresholdDraft] = React.useState(null)
       var [confirming, setConfirming] = React.useState(false)
       var [floated, setFloated] = React.useState(function () {
@@ -84,6 +120,7 @@ window.__ModuleLoader__.load({
         try { return window.localStorage.getItem('dshw-float-mode') === 'dot' } catch (e) { return false }
       })
       var [floatPos, setFloatPos] = React.useState(null)
+      var floatPosRef = React.useRef(null)
       var floatRef = React.useRef(null)
       var dragRef = React.useRef(null)
       var didDragRef = React.useRef(false)
@@ -100,7 +137,8 @@ window.__ModuleLoader__.load({
             if (!alive) return
             dataRef.current = json
             setData(json)
-            if (thresholdDraft === null && json.threshold !== undefined && json.threshold !== null) {
+            if (!thresholdInitializedRef.current && json.threshold !== undefined && json.threshold !== null) {
+              thresholdInitializedRef.current = true
               setThresholdDraft(json.threshold.toFixed(2))
             }
             if (json.lowBalance) {
@@ -120,28 +158,37 @@ window.__ModuleLoader__.load({
         tick()
         var timer = setInterval(tick, POLL_MS)
         return function () { alive = false; clearInterval(timer) }
-      }, [])
+      }, [sessionId])
       React.useEffect(function () {
         function onMove(event) {
           var d = dragRef.current
-          if (d === null) return
-          didDragRef.current = true
+          if (d === null || event.pointerId !== d.pointerId) return
           var x = Math.max(4, Math.min(window.innerWidth - d.w - 4, event.clientX - d.dx))
           var y = Math.max(4, Math.min(window.innerHeight - d.h - 4, event.clientY - d.dy))
-          setFloatPos({ x: x, y: y })
+          if (Math.abs(event.clientX - d.startX) > 3 || Math.abs(event.clientY - d.startY) > 3) didDragRef.current = true
+          d.x = x
+          d.y = y
+          floatPosRef.current = { x: x, y: y }
+          setFloatPos(floatPosRef.current)
         }
-        function onUp() {
-          if (dragRef.current === null) return
+        function onUp(event) {
+          var d = dragRef.current
+          if (d === null || event.pointerId !== d.pointerId) return
           dragRef.current = null
-          try { window.localStorage.setItem('dshw-float-pos', floatPos.x + ',' + floatPos.y) } catch (e) { /* ignore */ }
+          try { window.localStorage.setItem('dshw-float-pos', d.x + ',' + d.y) } catch (e) { /* ignore */ }
+          if (d.node && d.node.releasePointerCapture) {
+            try { d.node.releasePointerCapture(d.pointerId) } catch (e) { /* ignore */ }
+          }
         }
-        document.addEventListener('mousemove', onMove)
-        document.addEventListener('mouseup', onUp)
+        document.addEventListener('pointermove', onMove)
+        document.addEventListener('pointerup', onUp)
+        document.addEventListener('pointercancel', onUp)
         return function () {
-          document.removeEventListener('mousemove', onMove)
-          document.removeEventListener('mouseup', onUp)
+          document.removeEventListener('pointermove', onMove)
+          document.removeEventListener('pointerup', onUp)
+          document.removeEventListener('pointercancel', onUp)
         }
-      })
+      }, [])
 
       React.useEffect(function () {
         if (!open) return
@@ -152,36 +199,123 @@ window.__ModuleLoader__.load({
           if (confirmRef.current && confirmRef.current.contains(t)) return
           setOpen(false)
         }
-        document.addEventListener('mousedown', onDocDown)
-        return function () { document.removeEventListener('mousedown', onDocDown) }
-      }, [open])
+        function onKeyDown(event) {
+          if (event.key === 'Escape' && !confirming) {
+            setOpen(false)
+            if (chipButtonRef.current) chipButtonRef.current.focus()
+          }
+        }
+        document.addEventListener('pointerdown', onDocDown)
+        document.addEventListener('keydown', onKeyDown)
+        return function () {
+          document.removeEventListener('pointerdown', onDocDown)
+          document.removeEventListener('keydown', onKeyDown)
+        }
+      }, [open, confirming])
 
-      function readSavedPos() {
+      useLayoutEffect(function () {
+        if (!open || floated) return
+        var chipNode = chipRef.current
+        var panelNode = panelRef.current
+        if (chipNode === null || panelNode === null) return
+        function placePanel() {
+          var chipRect = chipNode.getBoundingClientRect()
+          var panelRect = panelNode.getBoundingClientRect()
+          setPanelStyle(computePanelPosition(chipRect, panelRect, window.innerWidth, window.innerHeight))
+        }
+        placePanel()
+        window.addEventListener('resize', placePanel)
+        window.addEventListener('scroll', placePanel, true)
+        return function () {
+          window.removeEventListener('resize', placePanel)
+          window.removeEventListener('scroll', placePanel, true)
+        }
+      }, [open, floated, data])
+
+      React.useEffect(function () {
+        if (!confirming) return
+        restoreFocusRef.current = document.activeElement
+        if (confirmButtonRef.current) confirmButtonRef.current.focus()
+        function onKeyDown(event) {
+          if (event.key === 'Escape') setConfirming(false)
+          if (event.key === 'Tab' && cancelButtonRef.current && confirmButtonRef.current) {
+            if (event.shiftKey && document.activeElement === cancelButtonRef.current) {
+              event.preventDefault()
+              confirmButtonRef.current.focus()
+            } else if (!event.shiftKey && document.activeElement === confirmButtonRef.current) {
+              event.preventDefault()
+              cancelButtonRef.current.focus()
+            }
+          }
+        }
+        document.addEventListener('keydown', onKeyDown)
+        return function () {
+          document.removeEventListener('keydown', onKeyDown)
+          var previous = restoreFocusRef.current
+          if (previous && typeof previous.focus === 'function') previous.focus()
+        }
+      }, [confirming])
+
+      function clampPos(pos, width, height) {
+        return clampPosition(pos, width, height, window.innerWidth, window.innerHeight)
+      }
+
+      function readSavedPos(width, height) {
         try {
           var raw = window.localStorage.getItem('dshw-float-pos')
           if (raw === null) return null
           var parts = raw.split(',')
           var x = Number.parseFloat(parts[0]); var y = Number.parseFloat(parts[1])
           if (Number.isFinite(x) && Number.isFinite(y)) {
-            var maxX = Math.max(4, window.innerWidth - 300)
-            var maxY = Math.max(4, window.innerHeight - 40)
-            return { x: Math.min(Math.max(4, x), maxX), y: Math.min(Math.max(4, y), maxY) }
+            return clampPos({ x: x, y: y }, width, height)
           }
         } catch (e) { /* ignore */ }
         return null
       }
 
       function onFloatDown(event) {
-        if (event.button !== 0) return
+        if (event.pointerType !== 'touch' && event.button !== 0) return
         var target = event.target
-        if (target && target.closest && target.closest('button,input,a')) return
         var node = floatRef.current
         if (node === null) return
+        if (target !== node && target && target.closest && target.closest('button,input,a')) return
         var rect = node.getBoundingClientRect()
-        dragRef.current = { dx: event.clientX - rect.left, dy: event.clientY - rect.top, w: rect.width, h: rect.height }
+        dragRef.current = {
+          pointerId: event.pointerId,
+          dx: event.clientX - rect.left,
+          dy: event.clientY - rect.top,
+          startX: event.clientX,
+          startY: event.clientY,
+          x: rect.left,
+          y: rect.top,
+          w: rect.width,
+          h: rect.height,
+          node: node
+        }
         didDragRef.current = false
+        if (node.setPointerCapture) {
+          try { node.setPointerCapture(event.pointerId) } catch (e) { /* ignore */ }
+        }
         event.preventDefault()
       }
+
+      useLayoutEffect(function () {
+        if (!floated || floatRef.current === null) return
+        var node = floatRef.current
+        function fitFloatingWindow() {
+          var rect = node.getBoundingClientRect()
+          var current = floatPosRef.current || readSavedPos(rect.width, rect.height) || {
+            x: window.innerWidth - rect.width - 16,
+            y: 80
+          }
+          var fitted = clampPos(current, rect.width, rect.height)
+          floatPosRef.current = fitted
+          setFloatPos(fitted)
+        }
+        fitFloatingWindow()
+        window.addEventListener('resize', fitFloatingWindow)
+        return function () { window.removeEventListener('resize', fitFloatingWindow) }
+      }, [floated, minimized])
 
       React.useEffect(function () {
         try {
@@ -222,7 +356,10 @@ window.__ModuleLoader__.load({
         }).then(function () {
           var url = '/api/wallet/snapshot'
           if (sessionId) url = url + '?session=' + encodeURIComponent(sessionId)
-          fetch(url).then(function (r) { return r.json() }).then(function (json) { setData(json) }).catch(function () {})
+          fetch(url).then(function (r) { return r.json() }).then(function (json) {
+            dataRef.current = json
+            setData(json)
+          }).catch(function () {})
         }).catch(function () {})
       }
 
@@ -231,7 +368,10 @@ window.__ModuleLoader__.load({
           setTimeout(function () {
             var url = '/api/wallet/snapshot'
             if (sessionId) url = url + '?session=' + encodeURIComponent(sessionId)
-            fetch(url).then(function (r2) { return r2.json() }).then(function (json) { setData(json) }).catch(function () { /* ignore */ })
+            fetch(url).then(function (r2) { return r2.json() }).then(function (json) {
+              dataRef.current = json
+              setData(json)
+            }).catch(function () { /* ignore */ })
           }, 300)
         }).catch(function () { /* ignore */ })
       }
@@ -262,56 +402,74 @@ window.__ModuleLoader__.load({
       var low = snapshot.lowBalance === true
 
       var chipTextParts = []
-      chipTextParts.push(React.createElement('span', { key: 'bal' }, '余额 ' + (bal.total === null || bal.total === undefined ? '--' : fmtMoney(bal.total))))
+      chipTextParts.push(React.createElement('span', { key: 'bal' }, '余额 ' + (bal.total === null || bal.total === undefined ? '--' : fmtCurrency(bal.total, bal.currency))))
       if (official.cost !== undefined && official.cost !== null) {
-        chipTextParts.push(React.createElement('span', { key: 'cost' }, '\u672c\u573a ' + fmtMoney(official.cost)))
+        chipTextParts.push(React.createElement('span', { key: 'cost' }, '\u672c\u573a ' + fmtCurrency(official.cost, 'CNY')))
       }
       chipTextParts.push(React.createElement('span', { key: 'off' }, '\u5b98 ' + fmtTokens(officialTokens)))
-      chipTextParts.push(React.createElement('span', { key: 'sep' }, '|'))
+      chipTextParts.push(React.createElement('span', { key: 'sep', className: 'dshw_sep' }, '|'))
       chipTextParts.push(React.createElement('span', { key: 'third' }, '\u4e09\u65b9 ' + fmtTokens(thirdTokens)))
-      chipTextParts.push(React.createElement('a', {
-        key: 'recharge',
-        className: 'dshw_recharge',
-        href: snapshot.rechargeUrl || 'https://platform.deepseek.com/top_up',
-        title: 'DeepSeek \u5f00\u653e\u5e73\u53f0 \u00b7 \u5b98\u65b9\u5145\u503c\u9875',
-        onClick: onRechargeClick
-      }, '\u2197\u5145'))
 
       var chip = React.createElement('span', {
         ref: chipRef,
         className: low ? 'dshw_chip dshw_chipLow' : 'dshw_chip',
-        title: 'deepseek-harness-wallet \u00b7 \u70b9\u51fb\u67e5\u770b\u660e\u7ec6',
-        onClick: function (event) {
+        role: 'group',
+        'aria-label': 'DeepSeek \u94b1\u5305'
+      },
+        React.createElement('button', {
+          ref: chipButtonRef,
+          type: 'button',
+          className: 'dshw_chipMain',
+          title: 'deepseek-harness-wallet \u00b7 \u70b9\u51fb\u67e5\u770b\u660e\u7ec6',
+          'aria-expanded': open,
+          'aria-haspopup': 'dialog',
+          onClick: function () {
           requestNotify()
-          if (floated) { setFloated(false); setOpen(true); return }
-          if (!open && chipRef.current) {
-            var rect = chipRef.current.getBoundingClientRect()
-            setAlignLeft(rect.left > rect.right - rect.left + 200)
+          if (floated) {
+            setFloated(false)
+            setPanelStyle({ visibility: 'hidden' })
+            setOpen(true)
+            return
           }
+          if (!open) setPanelStyle({ visibility: 'hidden' })
           setOpen(!open)
-        }
-      }, chipTextParts)
+          }
+        }, chipTextParts),
+        React.createElement('button', {
+          type: 'button',
+          className: 'dshw_recharge',
+          title: 'DeepSeek \u5f00\u653e\u5e73\u53f0 \u00b7 \u5b98\u65b9\u5145\u503c\u9875',
+          'aria-label': '\u6253\u5f00 DeepSeek \u5b98\u65b9\u5145\u503c\u9875',
+          onClick: onRechargeClick
+        }, '\u2197\u5145'))
 
       var confirmOverlay = null
       if (confirming) {
         confirmOverlay = React.createElement('div', { ref: confirmRef, className: 'dshw_overlay', onClick: function () { setConfirming(false) } },
-          React.createElement('div', { className: 'dshw_overlayBox', onClick: function (e) { e.stopPropagation() } },
-            React.createElement('div', null, '\u5c06\u6253\u5f00 DeepSeek \u5f00\u653e\u5e73\u53f0\u5b98\u65b9\u5145\u503c\u9875\uff1a'),
+          React.createElement('div', {
+            className: 'dshw_overlayBox',
+            role: 'dialog',
+            'aria-modal': 'true',
+            'aria-labelledby': 'dshw-confirm-title',
+            'aria-describedby': 'dshw-confirm-description',
+            onClick: function (e) { e.stopPropagation() }
+          },
+            React.createElement('div', { id: 'dshw-confirm-title', className: 'dshw_title' }, '\u5c06\u6253\u5f00 DeepSeek \u5f00\u653e\u5e73\u53f0\u5b98\u65b9\u5145\u503c\u9875\uff1a'),
             React.createElement('div', { className: 'dshw_muted' }, 'https://platform.deepseek.com/top_up'),
-            React.createElement('div', null, '\u767b\u5f55\u4e0e\u652f\u4ed8\u7531\u5b98\u65b9\u9875\u9762\u5b8c\u6210\uff0c\u672c\u63d2\u4ef6\u4e0d\u63a5\u89e6\u8d26\u53f7\u4e0e\u652f\u4ed8\u4fe1\u606f\u3002'),
+            React.createElement('div', { id: 'dshw-confirm-description' }, '\u767b\u5f55\u4e0e\u652f\u4ed8\u7531\u5b98\u65b9\u9875\u9762\u5b8c\u6210\uff0c\u672c\u63d2\u4ef6\u4e0d\u63a5\u89e6\u8d26\u53f7\u4e0e\u652f\u4ed8\u4fe1\u606f\u3002'),
             React.createElement('div', { className: 'dshw_overlayRow' },
-              React.createElement('button', { className: 'dshw_btn', onClick: function () { setConfirming(false) } }, '\u53d6\u6d88'),
-              React.createElement('button', { className: 'dshw_btn dshw_btnPrimary', onClick: goRecharge }, '\u53bb\u5145\u503c'))))
+              React.createElement('button', { ref: cancelButtonRef, type: 'button', className: 'dshw_btn', onClick: function () { setConfirming(false) } }, '\u53d6\u6d88'),
+              React.createElement('button', { ref: confirmButtonRef, type: 'button', className: 'dshw_btn dshw_btnPrimary', onClick: goRecharge }, '\u53bb\u5145\u503c'))))
       }
 
       if (!open && !floated) return React.createElement(React.Fragment, null, chip, confirmOverlay)
 
       var balanceRows = []
       if (bal.available && bal.balances && bal.balances.length > 0) {
-        bal.balances.forEach(function (info) {
-          balanceRows.push(React.createElement('div', { key: info.currency, className: 'dshw_row' },
+        bal.balances.forEach(function (info, index) {
+          balanceRows.push(React.createElement('div', { key: String(info.currency) + '-' + index, className: 'dshw_row' },
             React.createElement('span', { className: 'dshw_muted' }, '\u4f59\u989d (' + info.currency + ')'),
-            React.createElement('span', null, '\u00a5' + String(info.total_balance) + '  (\u5145\u503c ' + String(info.topped_up_balance) + ' / \u8d60\u9001 ' + String(info.granted_balance) + ')')
+            React.createElement('span', null, fmtCurrency(info.total_balance, info.currency) + '  (\u5145\u503c ' + fmtCurrency(info.topped_up_balance, info.currency) + ' / \u8d60\u9001 ' + fmtCurrency(info.granted_balance, info.currency) + ')')
           ))
         })
       } else {
@@ -326,7 +484,7 @@ window.__ModuleLoader__.load({
       }
       officialRows.push(React.createElement('div', { key: 'o-c', className: 'dshw_row' },
         React.createElement('span', { className: 'dshw_muted' }, '\u672c\u4f1a\u8bdd\u82b1\u8d39'),
-        React.createElement('span', null, official.cost === null ? '\u672a\u5b9a\u4ef7\u6a21\u578b' : '\u00a5' + fmtMoney(official.cost))))
+        React.createElement('span', null, official.cost === null ? '\u672a\u5b9a\u4ef7\u6a21\u578b' : fmtCurrency(official.cost, 'CNY'))))
 
       var thirdRows = []
       thirdRows.push(React.createElement('div', { key: 't-t', className: 'dshw_row' },
@@ -338,12 +496,17 @@ window.__ModuleLoader__.load({
         type: 'number',
         min: '0',
         step: 'any',
+        'aria-label': '\u4f59\u989d\u63d0\u9192\u9608\u503c\uff08CNY\uff09',
         value: thresholdDraft === null ? '' : thresholdDraft,
-        onChange: function (event) { setThresholdDraft(event.target.value) }
+        onChange: function (event) {
+          thresholdInitializedRef.current = true
+          setThresholdDraft(event.target.value)
+        }
       })
 
       var floatBtnRow = React.createElement('div', { className: 'dshw_row', style: { justifyContent: 'flex-end', marginTop: '2px' } },
         React.createElement('button', {
+          type: 'button',
           className: 'dshw_btn',
           style: { height: '22px', fontSize: '11px', padding: '0 10px' },
           title: '浮动窗口模式：可拖动、可最小化',
@@ -353,7 +516,9 @@ window.__ModuleLoader__.load({
       var panel = React.createElement('div', {
         ref: panelRef,
         className: 'dshw_panel',
-        style: alignLeft ? { left: 0, right: 'auto' } : undefined,
+        style: panelStyle,
+        role: 'dialog',
+        'aria-label': 'DeepSeek \u94b1\u5305\u660e\u7ec6',
         onClick: function (e) { e.stopPropagation() }
       },
         floatBtnRow,
@@ -368,16 +533,17 @@ window.__ModuleLoader__.load({
           React.createElement('span', { className: 'dshw_muted' }, '\u4f59\u989d\u63d0\u9192\u9608\u503c (\u00a5, 0=\u5173)'),
           thresholdInput),
         React.createElement('div', { className: 'dshw_row' },
-          React.createElement('button', { className: 'dshw_btn', onClick: refreshBalance }, '\u5237\u65b0\u4f59\u989d'),
-          React.createElement('button', { className: 'dshw_btn dshw_btnPrimary', onClick: saveThreshold }, '\u4fdd\u5b58\u9608\u503c')),
-        React.createElement('a', {
+          React.createElement('button', { type: 'button', className: 'dshw_btn', onClick: refreshBalance }, '\u5237\u65b0\u4f59\u989d'),
+          React.createElement('button', { type: 'button', className: 'dshw_btn dshw_btnPrimary', onClick: saveThreshold }, '\u4fdd\u5b58\u9608\u503c')),
+        React.createElement('button', {
+          type: 'button',
           className: 'dshw_btn dshw_btnPrimary',
-          href: snapshot.rechargeUrl || 'https://platform.deepseek.com/top_up',
-          style: { textDecoration: 'none', textAlign: 'center' },
+          style: { textAlign: 'center' },
           onClick: onRechargeClick
         }, '\u2197 \u53bb\u5b98\u65b9\u5145\u503c'),
         React.createElement('div', { className: 'dshw_divider' }),
         React.createElement('button', {
+          type: 'button',
           className: 'dshw_btn',
           style: { width: '100%' },
           onClick: function () {
@@ -388,33 +554,38 @@ window.__ModuleLoader__.load({
 
       if (floated) {
         if (minimized) {
-          var dotPos = floatPos || readSavedPos() || { x: window.innerWidth - 300, y: 80 }
-          var dot = React.createElement('div', {
+          var dotPos = floatPos || readSavedPos(36, 36) || { x: Math.max(4, window.innerWidth - 52), y: 80 }
+          var dot = React.createElement('button', {
             ref: floatRef,
+            type: 'button',
             className: low ? 'dshw_dot dshw_dotLow' : 'dshw_dot',
             style: { left: dotPos.x, top: dotPos.y },
             title: '钱包 · 点击展开',
-            onMouseDown: onFloatDown,
+            'aria-label': '钱包，点击展开',
+            onPointerDown: onFloatDown,
             onClick: function () { if (didDragRef.current !== true) setMinimized(false) }
-          }, '¥' + (bal.total === null || bal.total === undefined ? '--' : fmtMoney(bal.total)))
+          }, bal.total === null || bal.total === undefined ? '--' : fmtCurrency(bal.total, bal.currency))
           return React.createElement(React.Fragment, null, chip, dot, confirmOverlay)
         }
-        var winPos = floatPos || readSavedPos() || { x: window.innerWidth - 300, y: 80 }
+        var winPos = floatPos || readSavedPos(306, 340) || { x: Math.max(4, window.innerWidth - 322), y: 80 }
         var floatPanel = React.createElement('div', {
           ref: floatRef,
           className: 'dshw_float',
           style: { left: winPos.x, top: winPos.y },
-          onMouseDown: onFloatDown
+          role: 'dialog',
+          'aria-label': 'DeepSeek 浮动钱包'
         },
-          React.createElement('div', { className: 'dshw_floatHeader' },
+          React.createElement('div', { className: 'dshw_floatHeader', onPointerDown: onFloatDown },
             React.createElement('span', null, '钱包'),
             React.createElement('span', null,
               React.createElement('button', {
+                type: 'button',
                 className: 'dshw_floatBtn',
                 title: '最小化为圆点',
                 onClick: function (e) { e.stopPropagation(); setMinimized(true) }
               }, '–'),
               React.createElement('button', {
+                type: 'button',
                 className: 'dshw_floatBtn',
                 style: { marginLeft: '4px' },
                 title: '收回标签模式',
@@ -429,15 +600,16 @@ window.__ModuleLoader__.load({
             React.createElement('span', { className: 'dshw_muted' }, '阈值(¥,0=关)'),
             thresholdInput),
           React.createElement('div', { className: 'dshw_row' },
-            React.createElement('button', { className: 'dshw_btn', onClick: refreshBalance }, '刷新'),
-            React.createElement('button', { className: 'dshw_btn dshw_btnPrimary', onClick: saveThreshold }, '保存')),
-          React.createElement('a', {
+            React.createElement('button', { type: 'button', className: 'dshw_btn', onClick: refreshBalance }, '刷新'),
+            React.createElement('button', { type: 'button', className: 'dshw_btn dshw_btnPrimary', onClick: saveThreshold }, '保存')),
+          React.createElement('button', {
+            type: 'button',
             className: 'dshw_btn dshw_btnPrimary',
-            href: snapshot.rechargeUrl || 'https://platform.deepseek.com/top_up',
-            style: { textDecoration: 'none', textAlign: 'center' },
+            style: { textAlign: 'center' },
             onClick: onRechargeClick
           }, '↗ 充值'),
           React.createElement('button', {
+            type: 'button',
             className: 'dshw_btn', style: { width: '100%' },
             onClick: function () {
               if (window.confirm('确认清除本会话的 token 和花费记录？不可恢复。')) clearSession()
@@ -455,7 +627,7 @@ window.__ModuleLoader__.load({
       ctx.inject(['slots', 'conversation'], function (scope) {
         scope.effect(function () {
           return scope.slots.register({
-            name: 'conversation.composer.dock',
+            name: 'conversation.input.left',
             id: 'wallet',
             order: 130,
             inject: function () { return {} }
@@ -466,6 +638,11 @@ window.__ModuleLoader__.load({
 
     exports.apply = apply
     exports.inject = inject
+    exports.__testing = {
+      clampPosition: clampPosition,
+      computePanelPosition: computePanelPosition,
+      fmtCurrency: fmtCurrency
+    }
     return module.exports
   }
 })

--- a/lib/client.js
+++ b/lib/client.js
@@ -71,6 +71,7 @@ window.__ModuleLoader__.load({
       var notifiedRef = React.useRef(false)
       var chipRef = React.useRef(null)
       var panelRef = React.useRef(null)
+      var confirmRef = React.useRef(null)
       var [alignLeft, setAlignLeft] = React.useState(false)
       var [data, setData] = React.useState(null)
       var [open, setOpen] = React.useState(false)
@@ -148,6 +149,7 @@ window.__ModuleLoader__.load({
           var t = event.target
           if (chipRef.current && chipRef.current.contains(t)) return
           if (panelRef.current && panelRef.current.contains(t)) return
+          if (confirmRef.current && confirmRef.current.contains(t)) return
           setOpen(false)
         }
         document.addEventListener('mousedown', onDocDown)
@@ -290,7 +292,19 @@ window.__ModuleLoader__.load({
         }
       }, chipTextParts)
 
-      if (!open && !floated) return chip
+      var confirmOverlay = null
+      if (confirming) {
+        confirmOverlay = React.createElement('div', { ref: confirmRef, className: 'dshw_overlay', onClick: function () { setConfirming(false) } },
+          React.createElement('div', { className: 'dshw_overlayBox', onClick: function (e) { e.stopPropagation() } },
+            React.createElement('div', null, '\u5c06\u6253\u5f00 DeepSeek \u5f00\u653e\u5e73\u53f0\u5b98\u65b9\u5145\u503c\u9875\uff1a'),
+            React.createElement('div', { className: 'dshw_muted' }, 'https://platform.deepseek.com/top_up'),
+            React.createElement('div', null, '\u767b\u5f55\u4e0e\u652f\u4ed8\u7531\u5b98\u65b9\u9875\u9762\u5b8c\u6210\uff0c\u672c\u63d2\u4ef6\u4e0d\u63a5\u89e6\u8d26\u53f7\u4e0e\u652f\u4ed8\u4fe1\u606f\u3002'),
+            React.createElement('div', { className: 'dshw_overlayRow' },
+              React.createElement('button', { className: 'dshw_btn', onClick: function () { setConfirming(false) } }, '\u53d6\u6d88'),
+              React.createElement('button', { className: 'dshw_btn dshw_btnPrimary', onClick: goRecharge }, '\u53bb\u5145\u503c'))))
+      }
+
+      if (!open && !floated) return React.createElement(React.Fragment, null, chip, confirmOverlay)
 
       var balanceRows = []
       if (bal.available && bal.balances && bal.balances.length > 0) {
@@ -371,18 +385,6 @@ window.__ModuleLoader__.load({
           }
         }, '\u6e05\u9664\u672c\u4f1a\u8bdd\u6570\u636e')
       )
-
-      var confirmOverlay = null
-      if (confirming) {
-        confirmOverlay = React.createElement('div', { className: 'dshw_overlay', onClick: function () { setConfirming(false) } },
-          React.createElement('div', { className: 'dshw_overlayBox', onClick: function (e) { e.stopPropagation() } },
-            React.createElement('div', null, '\u5c06\u6253\u5f00 DeepSeek \u5f00\u653e\u5e73\u53f0\u5b98\u65b9\u5145\u503c\u9875\uff1a'),
-            React.createElement('div', { className: 'dshw_muted' }, 'https://platform.deepseek.com/top_up'),
-            React.createElement('div', null, '\u767b\u5f55\u4e0e\u652f\u4ed8\u7531\u5b98\u65b9\u9875\u9762\u5b8c\u6210\uff0c\u672c\u63d2\u4ef6\u4e0d\u63a5\u89e6\u8d26\u53f7\u4e0e\u652f\u4ed8\u4fe1\u606f\u3002'),
-            React.createElement('div', { className: 'dshw_overlayRow' },
-              React.createElement('button', { className: 'dshw_btn', onClick: function () { setConfirming(false) } }, '\u53d6\u6d88'),
-              React.createElement('button', { className: 'dshw_btn dshw_btnPrimary', onClick: goRecharge }, '\u53bb\u5145\u503c'))))
-      }
 
       if (floated) {
         if (minimized) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepseek-harness-wallet",
   "description": "Balance monitoring, per-session spend tracking, token statistics, low-balance alerts, and an official recharge shortcut for DeepSeek Harness.",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "type": "module",
   "main": "index.js",
   "exports": {

--- a/test/wallet.test.mjs
+++ b/test/wallet.test.mjs
@@ -5,11 +5,15 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
+import { runInNewContext } from 'node:vm'
 import {
   PRICE_POLICIES,
+  addOfficialUsage,
+  balanceCurrency,
   isBeijingPeak,
   ratesFor,
   costOf,
+  normalizeStoreData,
   normalizeThreshold,
   sumBalances,
 } from '../index.js'
@@ -17,6 +21,98 @@ import {
 // Beijing wall-clock helper: ms timestamp for a Beijing local time.
 function bj(y, m, d, h, min = 0) {
   return Date.UTC(y, m - 1, d, h - 8, min)
+}
+
+function loadClientBundle(React) {
+  const source = readFileSync(new URL('../lib/client.js', import.meta.url), 'utf8')
+  let definition
+  const values = new Map()
+  const window = {
+    __ModuleLoader__: { load(value) { definition = value } },
+    innerWidth: 1359,
+    innerHeight: 851,
+    localStorage: {
+      getItem(key) { return values.has(key) ? values.get(key) : null },
+      setItem(key, value) { values.set(key, String(value)) },
+    },
+  }
+  runInNewContext(source, { window })
+  assert.ok(definition, 'client bundle must register with the module loader')
+  return {
+    exports: definition.factory((id) => {
+      assert.equal(id, 'react')
+      return React
+    }),
+    window,
+  }
+}
+
+function createHookRenderer() {
+  const hooks = []
+  let cursor = 0
+  const React = {
+    Fragment: Symbol('Fragment'),
+    createElement(type, props, ...children) {
+      return {
+        type,
+        props: { ...(props || {}), children: children.length === 1 ? children[0] : children },
+      }
+    },
+    useRef(initial) {
+      const index = cursor++
+      if (!(index in hooks)) hooks[index] = { current: initial }
+      return hooks[index]
+    },
+    useState(initial) {
+      const index = cursor++
+      if (!(index in hooks)) hooks[index] = typeof initial === 'function' ? initial() : initial
+      return [hooks[index], (value) => {
+        hooks[index] = typeof value === 'function' ? value(hooks[index]) : value
+      }]
+    },
+    useEffect() { cursor++ },
+    useLayoutEffect() { cursor++ },
+  }
+  return {
+    React,
+    render(Component, props) {
+      cursor = 0
+      return Component(props)
+    },
+  }
+}
+
+function findElement(node, predicate) {
+  if (node === null || node === undefined || typeof node !== 'object') return null
+  if (Array.isArray(node)) {
+    for (const child of node) {
+      const match = findElement(child, predicate)
+      if (match) return match
+    }
+    return null
+  }
+  if (predicate(node)) return node
+  return findElement(node.props && node.props.children, predicate)
+}
+
+function walletComponent(bundleExports) {
+  let Component
+  let slot
+  bundleExports.apply({
+    inject(_names, callback) {
+      callback({
+        effect(run) { run() },
+        slots: {
+          register(definition, value) {
+            slot = definition
+            Component = value
+            return () => {}
+          },
+        },
+      })
+    },
+  })
+  return { Component, slot }
 }
 
 test('client bundle registers the loader under the package name', () => {
@@ -167,4 +263,113 @@ test('sumBalances: prefers the CNY record, never mixes currencies', () => {
   assert.equal(sumBalances(null), 0)
   // Non-numeric records are ignored rather than NaN-poisoning the total.
   assert.equal(sumBalances([{ currency: 'CNY', total_balance: 'nope' }, usd]), 50)
+})
+
+test('official cost is accumulated at usage time and remains stable later', () => {
+  const bucket = { models: {}, cost: 0, priced: true }
+  const usage = { inputTokens: 1_000_000, outputTokens: 1_000_000, cacheReadTokens: 1_000_000 }
+  addOfficialUsage(bucket, 'deepseek-v4-pro', usage, bj(2026, 8, 17, 22, 0))
+  assert.equal(bucket.cost, 18.15)
+  addOfficialUsage(bucket, 'deepseek-v4-pro', usage, bj(2026, 8, 18, 10, 0))
+  assert.ok(Math.abs(bucket.cost - 54.45) < 1e-12)
+  assert.equal(bucket.models['deepseek-v4-pro'].input, 2_000_000)
+
+  const normalized = normalizeStoreData({
+    version: 2,
+    threshold: 5,
+    sessions: { current: { official: bucket, third: { models: {} } } },
+  }, bj(2026, 8, 19, 22, 0))
+  assert.ok(Math.abs(normalized.store.sessions.current.official.cost - 54.45) < 1e-12)
+  assert.equal(normalized.migrated, false)
+})
+
+test('legacy stores migrate once and malformed counters are sanitized', () => {
+  const legacy = {
+    threshold: '7.25',
+    sessions: {
+      old: {
+        official: { models: { 'deepseek-v4-pro': {
+          input: 1_000_000,
+          output: 1_000_000,
+          cacheRead: 1_000_000,
+          cacheWrite: -10,
+          reasoning: 'bad',
+        } } },
+        third: { models: {} },
+      },
+    },
+  }
+  const first = normalizeStoreData(legacy, bj(2026, 8, 17, 22, 0))
+  assert.equal(first.migrated, true)
+  assert.equal(first.store.version, 2)
+  assert.equal(first.store.threshold, 7.25)
+  assert.equal(first.store.sessions.old.official.cost, 18.15)
+  assert.equal(first.store.sessions.old.official.models['deepseek-v4-pro'].cacheWrite, 0)
+  assert.equal(first.store.sessions.old.official.models['deepseek-v4-pro'].reasoning, 0)
+
+  const second = normalizeStoreData(first.store, bj(2026, 8, 18, 10, 0))
+  assert.equal(second.migrated, false)
+  assert.equal(second.store.sessions.old.official.cost, 18.15)
+})
+
+test('unknown official models retain tokens and mark the session cost unpriced', () => {
+  const bucket = { models: {}, cost: 0, priced: true }
+  addOfficialUsage(bucket, 'future-model', { inputTokens: 123, outputTokens: 45 }, Date.now())
+  assert.equal(bucket.priced, false)
+  assert.equal(bucket.cost, 0)
+  assert.equal(bucket.models['future-model'].input, 123)
+  assert.equal(bucket.models['future-model'].output, 45)
+})
+
+test('balance currency follows the selected balance row', () => {
+  assert.equal(balanceCurrency([{ currency: 'USD', total_balance: '8.50' }]), 'USD')
+  assert.equal(balanceCurrency([
+    { currency: 'USD', total_balance: '8.50' },
+    { currency: 'CNY', total_balance: '2.00' },
+  ]), 'CNY')
+  assert.equal(balanceCurrency([{ currency: 'CNY', total_balance: 'bad' }]), null)
+})
+
+test('client layout flips above a bottom-edge chip and clamps each floating size', () => {
+  const { React } = createHookRenderer()
+  const { exports } = loadClientBundle(React)
+  const above = exports.__testing.computePanelPosition(
+    { left: 1100, top: 820, bottom: 843 },
+    { width: 300, height: 340 },
+    1359,
+    851,
+  )
+  assert.equal(above.left, 1051)
+  assert.equal(above.top, 474)
+  assert.equal(above.visibility, 'visible')
+
+  const below = exports.__testing.computePanelPosition(
+    { left: 20, top: 20, bottom: 42 },
+    { width: 300, height: 340 },
+    1359,
+    851,
+  )
+  assert.equal(below.top, 48)
+  assert.equal(exports.__testing.clampPosition({ x: 2000, y: 900 }, 36, 36, 1359, 851).x, 1319)
+  assert.equal(exports.__testing.clampPosition({ x: 2000, y: 900 }, 306, 340, 1359, 851).x, 1049)
+})
+
+test('client uses native controls, keeps first-click recharge confirmation, and registers an interactive slot', () => {
+  const renderer = createHookRenderer()
+  const { exports } = loadClientBundle(renderer.React)
+  const { Component, slot } = walletComponent(exports)
+  assert.equal(slot.name, 'conversation.input.left')
+
+  let tree = renderer.render(Component, { sessionId: 'session-1' })
+  const mainButton = findElement(tree, (element) => element.type === 'button' && element.props.className === 'dshw_chipMain')
+  const rechargeButton = findElement(tree, (element) => element.type === 'button' && element.props.className === 'dshw_recharge')
+  assert.ok(mainButton)
+  assert.ok(rechargeButton)
+  assert.equal(mainButton.props['aria-haspopup'], 'dialog')
+  assert.equal(findElement(tree, (element) => element.type === 'a'), null)
+
+  rechargeButton.props.onClick({ preventDefault() {}, stopPropagation() {} })
+  tree = renderer.render(Component, { sessionId: 'session-1' })
+  const confirmation = findElement(tree, (element) => element.props && element.props.role === 'dialog' && element.props['aria-modal'] === 'true')
+  assert.ok(confirmation, 'the first recharge click must render a confirmation dialog even while details are closed')
 })


### PR DESCRIPTION
## Summary

- include QZYWQ's PR #2 fix for first-click recharge confirmation
- lock session cost to each usage event's pricing window and migrate legacy stores to schema v2
- keep the detail panel inside the viewport, correct multi-currency formatting, and harden floating drag
- improve keyboard/dialog semantics and move the interactive wallet to `conversation.input.left`
- prepare package metadata and bilingual release notes for v0.1.3

## Verification

- `npm test` — 18/18 passed on Node 24
- `npx node@22.19.0 --test` — 18/18 passed
- host and browser syntax checks passed
- `npm pack --dry-run --json` passed (6 files, zero dependencies)
- Edge QA in an isolated real Harness profile passed panel flip, first-click confirmation, Esc/focus restore, pointer drag, dot/window clamping, and browser error-log checks

The CI matrix improvement will be committed through GitHub's web editor because the current CLI OAuth token cannot modify workflow files.