### PR TITLE
Release v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
-All notable changes to this project are documented here.
+All notable changes to this project are documented in this file.
+
+## 0.1.5 - 2026-08-18
+
+- 修复输入框内的余额标签被固定压缩成 44px 极简显示的问题，现在按实际可用空间在完整 / 紧凑 / 极简三档间自动切换。 / Fixed the composer chip always collapsing to its 44px compact value; it now switches between full, fit, and compact layouts by measured space.
+- 修复缩放比例不等于 100% 时被误判为空间不足的问题。 / Fixed compact mode being mis-triggered whenever the scale was not 100%.
+- 修复芯片拖到输入框旁悬浮时被其他面板遮挡的问题。 / Fixed docked chips being covered by neighbouring host panels.
+- 输入框内缩放上限调整为 120%，悬浮 / 侧边停靠时仍可到 125%。 / The scale slider is capped at 120% in the composer row; floating and side docks keep the full 75–125% range.
 
 ## 0.1.4 - 2026-08-17
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -250,7 +250,8 @@ window.__ModuleLoader__.load({
 
     var css = [
       '.dshw_anchor{display:inline-flex;align-items:center;min-height:22px;min-width:0;vertical-align:middle}',
-      '.dshw_anchorHome{container-name:dshw-home;container-type:inline-size;overflow:hidden;min-width:44px}',
+      '.dshw_anchorHome{overflow:hidden;min-width:44px}',
+      '.dshw_chipLift{z-index:80!important}',
       '.dshw_anchorHome>.dshw_chip{box-sizing:border-box;max-width:100%;min-width:0;overflow:hidden}',
       '.dshw_chip{border:1px solid var(--dsw-alias-border-l2,rgba(0,0,0,.15));background:transparent;height:22px;color:var(--dsw-alias-label-primary,#1f2328);white-space:nowrap;border-radius:999px;align-items:stretch;font-size:12px;line-height:1;display:inline-flex;position:relative;touch-action:none;user-select:none;cursor:grab}',
       '.dshw_chip:hover,.dshw_chip:focus-within{border-color:var(--dsw-alias-brand-primary,#4aa3ff)}',
@@ -307,8 +308,13 @@ window.__ModuleLoader__.load({
       '.dshw_notice{box-sizing:border-box;width:100%;display:flex;align-items:flex-start;gap:8px;padding:10px 10px 10px 12px;border:1px solid var(--dsw-alias-border-l2,rgba(0,0,0,.15));border-radius:9px;background:var(--dsw-alias-bg-overlay,#fff);color:var(--dsw-alias-label-primary,#1f2328);box-shadow:0 6px 20px rgba(0,0,0,.2);font-size:12px;line-height:1.45;pointer-events:auto;cursor:pointer}',
       '.dshw_noticeCopy{min-width:0;display:flex;flex:1;flex-direction:column;gap:2px}.dshw_noticeCopy span{white-space:pre-line;overflow-wrap:anywhere}',
       '.dshw_noticeClose{flex:none;width:24px;height:24px;border:0;border-radius:5px;background:transparent;color:inherit;font-size:18px;line-height:1;cursor:pointer}.dshw_noticeClose:hover{background:var(--dsw-alias-interactive-bg-hover,rgba(0,0,0,.06))}',
-      '@container dshw-home (max-width:90px){.dshw_anchorHome .dshw_chip{width:100%}.dshw_anchorHome .dshw_chipMain{box-sizing:border-box;width:100%;min-width:0;overflow:hidden;justify-content:center;padding:0 3px}.dshw_anchorHome .dshw_chipMain>span{display:none}.dshw_anchorHome .dshw_chipMain>.dshw_homePrimary{display:inline;min-width:0;overflow:hidden;text-overflow:ellipsis}.dshw_anchorHome .dshw_homePrimaryLabel{display:none}.dshw_anchorHome .dshw_recharge{display:none}}',
-      '@supports not (container-type:inline-size){@media (max-width:640px){.dshw_anchorHome .dshw_chip{width:100%}.dshw_anchorHome .dshw_chipMain{box-sizing:border-box;width:100%;min-width:0;overflow:hidden;justify-content:center;padding:0 3px}.dshw_anchorHome .dshw_chipMain>span{display:none}.dshw_anchorHome .dshw_chipMain>.dshw_homePrimary{display:inline;min-width:0;overflow:hidden;text-overflow:ellipsis}.dshw_anchorHome .dshw_homePrimaryLabel{display:none}.dshw_anchorHome .dshw_recharge{display:none}}}',
+      // Home-fit and compact modes are toggled by measured space (see the
+      // home-space effect in WalletChip), not by container queries:
+      // container-type:inline-size on a content-sized flex item detaches its
+      // width from the chip, so flex layouts resolve it to min-width (44px)
+      // even when the row has room.
+      '.dshw_anchorHome.dshw_fit .dshw_chipMain>span:not(.dshw_homePrimary){display:none}',
+      '.dshw_anchorHome.dshw_compact .dshw_chip{width:100%}.dshw_anchorHome.dshw_compact .dshw_chipMain{box-sizing:border-box;width:100%;min-width:0;overflow:hidden;justify-content:center;padding:0 3px}.dshw_anchorHome.dshw_compact .dshw_chipMain>span{display:none}.dshw_anchorHome.dshw_compact .dshw_chipMain>.dshw_homePrimary{display:inline;min-width:0;overflow:hidden;text-overflow:ellipsis}.dshw_anchorHome.dshw_compact .dshw_homePrimaryLabel{display:none}.dshw_anchorHome.dshw_compact .dshw_recharge{display:none}',
       '@media (max-width:420px){.dshw_chipDocked:not(.dshw_chipVertical){max-width:calc(100vw - 4px);font-size:10px}.dshw_chipDocked:not(.dshw_chipVertical) .dshw_chipMain{gap:3px;padding:0 4px}.dshw_chipDocked:not(.dshw_chipVertical) .dshw_recharge{padding:0 4px}}'
     ].join('')
 
@@ -687,6 +693,18 @@ window.__ModuleLoader__.load({
       return node || null
     }
 
+    function isStackingContext(style) {
+      if (!style) return false
+      if (style.position === 'fixed' || style.position === 'sticky') return true
+      if (style.zIndex !== 'auto' && style.position !== 'static') return true
+      if (style.transform !== 'none' || style.filter !== 'none' || style.perspective !== 'none') return true
+      if (style.willChange === 'transform' || style.willChange === 'filter' || style.willChange === 'opacity' || style.willChange === 'z-index') return true
+      if (style.contain && style.contain !== 'none') return true
+      if (style.isolation === 'isolate') return true
+      if (style.opacity !== '1') return true
+      return false
+    }
+
     function findComposerRect(node, viewportWidth, viewportHeight) {
       var composer = findComposerNode(node, viewportWidth, viewportHeight)
       return composer && typeof composer.getBoundingClientRect === 'function' ? composer.getBoundingClientRect() : null
@@ -799,6 +817,8 @@ window.__ModuleLoader__.load({
       var [chipScale, setChipScale] = React.useState(function () {
         try { return normalizeChipScale(compatibility.storage.getItem(CHIP_SCALE_KEY)) } catch (e) { return 1 }
       })
+      var [homeMode, setHomeMode] = React.useState('full')
+      var chipLiftHostRef = React.useRef(null)
       var [dataVisibility, setDataVisibility] = React.useState(function () {
         try {
           var savedVisibility = compatibility.storage.getItem(DATA_VISIBILITY_KEY)
@@ -855,6 +875,8 @@ window.__ModuleLoader__.load({
 
       function saveChipScale(next) {
         next = normalizeChipScale(next)
+        var cap = chipLayoutRef.current.dock === 'home' ? 1.2 : 1.25
+        if (next > cap) next = cap
         chipScaleRef.current = next
         setChipScale(next)
         try { compatibility.storage.setItem(CHIP_SCALE_KEY, String(next)) } catch (e) { /* ignore */ }
@@ -1211,6 +1233,35 @@ window.__ModuleLoader__.load({
         if (event.preventDefault) event.preventDefault()
       }
 
+      // A docked chip is position:fixed, but it still renders inside the host
+      // composer subtree; hosts commonly wrap that subtree in a low stacking
+      // context (dsh uses z-index:1), which caps the chip under neighbouring
+      // top-level panels. The node must stay in place so React's delegated
+      // events keep working, so instead lift the outermost trapping ancestor
+      // context while any dock mode is active.
+      useLayoutEffect(function () {
+        if (chipLayout.dock === 'home') return
+        var node = chipAnchorRef.current
+        if (node === null || typeof window === 'undefined' || !window.getComputedStyle) return
+        var outermost = null
+        while (node && node !== document.body) {
+          if (isStackingContext(window.getComputedStyle(node))) outermost = node
+          node = node.parentElement
+        }
+        chipLiftHostRef.current = outermost
+        if (outermost && outermost.classList) outermost.classList.add('dshw_chipLift')
+        return function () {
+          if (outermost && outermost.classList) outermost.classList.remove('dshw_chipLift')
+          if (chipLiftHostRef.current === outermost) chipLiftHostRef.current = null
+        }
+      }, [chipLayout.dock])
+
+      // A stored 125% from a floating/side dock must come back down when the
+      // chip returns to the space-constrained home row.
+      React.useEffect(function () {
+        if (chipLayout.dock === 'home' && chipScaleRef.current > 1.2) saveChipScale(1.2)
+      }, [chipLayout.dock])
+
       useLayoutEffect(function () {
         var node = chipRef.current
         if (node === null) return
@@ -1218,6 +1269,55 @@ window.__ModuleLoader__.load({
         var measured = { width: rect.width, height: rect.height, scale: chipScaleRef.current }
         if (node.classList && node.classList.contains('dshw_chipVertical')) chipSizeRef.current.vertical = measured
         else chipSizeRef.current.horizontal = measured
+      }, [chipLayout.dock, chipScale, data, showOfficial, showThird, homeMode])
+
+      useLayoutEffect(function () {
+        if (chipLayout.dock !== 'home') return
+        var anchor = chipAnchorRef.current
+        var chip = chipRef.current
+        if (!anchor || !chip) return
+
+        function measureHomeMode() {
+          var current = chipAnchorRef.current
+          var chipNode = chipRef.current
+          if (!current || !chipNode) return null
+          // Try each tier in place and let the composer row's own flex pressure
+          // accept or squeeze it: a tier fits when the chip's allocated width
+          // matches its content width. All readings come from the chip itself
+          // so the scale slider's zoom factor cancels out; the anchor's
+          // parent slot wrapper can be display:contents, so measuring
+          // ancestors is not reliable.
+          var compact = current.classList.contains('dshw_compact')
+          current.classList.remove('dshw_compact')
+          current.classList.remove('dshw_fit')
+          var mode
+          if (chipNode.clientWidth >= chipNode.scrollWidth - 1) {
+            mode = 'full'
+          } else {
+            current.classList.add('dshw_fit')
+            mode = chipNode.clientWidth >= chipNode.scrollWidth - 1 ? 'fit' : 'compact'
+            current.classList.remove('dshw_fit')
+          }
+          if (compact) current.classList.add('dshw_compact')
+          return mode
+        }
+
+        function evaluateHomeSpace() {
+          var next = measureHomeMode()
+          if (next) setHomeMode(next)
+        }
+
+        evaluateHomeSpace()
+        window.addEventListener('resize', evaluateHomeSpace)
+        var observer = typeof ResizeObserver !== 'undefined' ? new ResizeObserver(evaluateHomeSpace) : null
+        if (observer) {
+          observer.observe(anchor)
+          observer.observe(chip)
+        }
+        return function () {
+          window.removeEventListener('resize', evaluateHomeSpace)
+          if (observer) observer.disconnect()
+        }
       }, [chipLayout.dock, chipScale, data, showOfficial, showThird])
 
       useLayoutEffect(function () {
@@ -1377,6 +1477,9 @@ window.__ModuleLoader__.load({
       var thirdTokens = third.tokens ? totalTokens(third.tokens) : 0
       var low = showOfficial && snapshot.lowBalance === true
       var chipDock = chipLayout.dock
+      // The home toolbar row cannot fit the widest scale on narrow windows, so
+      // cap the slider there; floating and side docks keep the full range.
+      var scaleMaxPercent = chipDock === 'home' ? 120 : 125
       var chipVertical = chipDock === 'left' || chipDock === 'right' || chipDock === 'content-left'
       var chipClass = low ? 'dshw_chip dshw_chipLow' : 'dshw_chip'
       var cssZoom = compatibility.supportsCssZoom()
@@ -1455,7 +1558,7 @@ window.__ModuleLoader__.load({
           onClick: onRechargeClick
         }, '\u2197\u5145') : null)
 
-      var chipHost = React.createElement('span', { ref: chipAnchorRef, className: chipDock === 'home' ? 'dshw_anchor dshw_anchorHome' : 'dshw_anchor' }, chip)
+      var chipHost = React.createElement('span', { ref: chipAnchorRef, className: chipDock === 'home' ? 'dshw_anchor dshw_anchorHome' + (homeMode === 'compact' ? ' dshw_compact' : homeMode === 'fit' ? ' dshw_fit' : '') : 'dshw_anchor' }, chip)
       var snapPreviewElement = snapPreview ? React.createElement('div', {
         className: snapPreview.vertical ? 'dshw_snapPreview dshw_snapPreviewVertical' : 'dshw_snapPreview',
         style: { left: snapPreview.x, top: snapPreview.y, width: snapPreview.width, height: snapPreview.height },
@@ -1531,7 +1634,7 @@ window.__ModuleLoader__.load({
             className: 'dshw_scaleInput',
             type: 'range',
             min: '75',
-            max: '125',
+            max: String(scaleMaxPercent),
             step: '5',
             value: String(Math.round(chipScale * 100)),
             'aria-label': '钱包芯片比例',

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepseek-harness-wallet",
   "description": "Local-first account monitoring, usage accounting, official recharge, completion reminders, flexible layout, and host-gated session controls for DeepSeek Harness.",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "type": "module",
   "main": "index.js",
   "exports": {

--- a/test/wallet.test.mjs
+++ b/test/wallet.test.mjs
@@ -214,7 +214,7 @@ test('release READMEs use only approved status badges and every local Markdown t
 test('release identity and intended npm archive inventory stay aligned', () => {
   const pkg = JSON.parse(readProjectFile('package.json'))
   assert.equal(pkg.name, 'deepseek-harness-wallet')
-  assert.equal(pkg.version, '0.1.4')
+  assert.equal(pkg.version, '0.1.5')
   assert.equal(pkg.main, 'index.js')
   assert.equal(pkg.dsh.client.platform, 'web')
   assert.deepEqual(pkg.files, [
@@ -609,7 +609,7 @@ test('wallet chip scale is stepped, bounded, and drives a live slider', () => {
   assert.ok(slider)
   assert.equal(slider.props.type, 'range')
   assert.equal(slider.props.min, '75')
-  assert.equal(slider.props.max, '125')
+  assert.equal(slider.props.max, '120', 'the default home dock caps the slider at 120%')
   slider.props.onChange({ target: { value: '85' } })
   tree = renderer.render(Component, { sessionId: 'session-1' })
   chip = findElement(tree, (element) => element.props && element.props['aria-label'] === 'DeepSeek 钱包')
@@ -621,8 +621,13 @@ test('home chip keeps a clickable compact value when the composer slot shrinks',
   const source = readProjectFile('lib/client.js')
   assert.match(source, /\.dshw_anchorHome\{[^}]*overflow:hidden/)
   assert.match(source, /\.dshw_anchorHome\{[^}]*min-width:44px/)
-  assert.match(source, /@container dshw-home \(max-width:90px\)/)
-  assert.match(source, /\.dshw_anchorHome \.dshw_recharge\{display:none\}/)
+  assert.ok(!/@container dshw-home/.test(source), 'container queries must not size the home anchor: inline-size containment collapses it to the 44px minimum even in roomy composers')
+  assert.match(source, /\.dshw_anchorHome\.dshw_compact \.dshw_recharge\{display:none\}/)
+  assert.match(source, /\.dshw_anchorHome\.dshw_fit \.dshw_chipMain>span:not\(\.dshw_homePrimary\)\{display:none\}/, 'a tight row must degrade to balance plus recharge before collapsing to the bare value')
+  assert.match(source, /chipNode\.clientWidth >= chipNode\.scrollWidth - 1 \? 'fit' : 'compact'/, 'home sizing must let the composer row decide between full, fit, and compact modes')
+  assert.match(source, /dock === 'home' \? 1\.2 : 1\.25/, 'the scale cap must tighten to 120% while the chip is docked in the composer')
+  assert.match(source, /max: String\(scaleMaxPercent\)/, 'the slider max must follow the dock-specific scale cap')
+  assert.match(source, /chipScaleRef\.current > 1\.2\) saveChipScale\(1\.2\)/, 'a stored 125% must clamp down when the chip returns home')
 
   const renderer = createHookRenderer()
   const { exports } = loadClientBundle(renderer.React)
@@ -634,6 +639,14 @@ test('home chip keeps a clickable compact value when the composer slot shrinks',
   assert.ok(primary, 'the compact state must preserve the official balance as its primary value')
   assert.equal(primary.props.children[0].props.className, 'dshw_homePrimaryLabel')
   assert.equal(primary.props.children[1].props.className, 'dshw_homePrimaryValue')
+})
+
+test('docked chip escapes the composer stacking context', () => {
+  const source = readProjectFile('lib/client.js')
+  assert.match(source, /\.dshw_chipLift\{z-index:80!important\}/, 'the lift class must outrank host panels that cover docked chips')
+  assert.match(source, /isStackingContext\(/, 'trapping ancestor stacking contexts must be detected')
+  assert.match(source, /outermost\.classList\.add\('dshw_chipLift'\)/, 'the outermost trapping ancestor must be lifted while docked')
+  assert.match(source, /outermost\.classList\.remove\('dshw_chipLift'\)/, 'the lift must be removed when the effect cleans up')
 })
 
 test('official and third-party displays can be selected independently', () => {


### PR DESCRIPTION
## 修复 / Fixes

- 输入框内余额标签固定被压成 44px 极简显示 → 按实际空间三档自动切换 / The composer chip no longer collapses to its 44px compact value; it switches between full, fit, and compact by measured space
- 缩放 ≠ 100% 时误判空间不足 / Compact mode no longer mis-triggers at non-100% scale
- 悬浮停靠时被邻近面板遮挡 / Docked chips are no longer covered by neighbouring panels
- 输入框内缩放上限 120%（其余位置仍 125%）/ Scale capped at 120% in the composer row (125% elsewhere)

45/45 tests pass. Verified live on dsh 0.1.0-rc.7 (Windows + Edge).