### PR TITLE
feat: settings gear beside the balance chip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project are documented in this file.
 
+## 0.2.0 - 2026-08-18
+
+- 新增多账户管理与热切换：面板内“账户管理”可添加多个账户（名称 + API Key），切换后无需重启，下一次 LLM 调用即按新账户计费；key 界面掩码显示，余额查询跟随当前账户（contributed in PR #4 by mxchen-xyz）。 / Added multi-account management with hot switching: manage accounts in the panel, and the very next LLM call is billed with the newly activated key — no restart needed; keys stay masked in the UI and balance follows the active account.
+- 余额标签右侧新增 ⚙ 设置入口，点击直接打开钱包设置面板。 / Added a ⚙ settings entry beside the balance chip that opens the control panel directly.
+
 ## 0.1.5 - 2026-08-18
 
 - 修复输入框内的余额标签被固定压缩成 44px 极简显示的问题，现在按实际可用空间在完整 / 紧凑 / 极简三档间自动切换。 / Fixed the composer chip always collapsing to its 44px compact value; it now switches between full, fit, and compact layouts by measured space.

--- a/lib/client.js
+++ b/lib/client.js
@@ -271,12 +271,14 @@ window.__ModuleLoader__.load({
       '.dshw_bottomDockHost{box-sizing:border-box!important;padding-bottom:30px!important}',
       '@keyframes dshwPulse{0%,100%{box-shadow:0 0 0 0 rgba(229,83,75,.45)}50%{box-shadow:0 0 0 5px rgba(229,83,75,0)}}',
       '.dshw_sep{opacity:.45}',
-      '.dshw_chipMain,.dshw_recharge{border:0;background:transparent;color:inherit;font:inherit;cursor:pointer;align-items:center;display:inline-flex;gap:6px;margin:0}',
+      '.dshw_chipMain,.dshw_recharge,.dshw_gear{border:0;background:transparent;color:inherit;font:inherit;cursor:pointer;align-items:center;display:inline-flex;gap:6px;margin:0}',
       '.dshw_chipMain{padding:0 7px;border-radius:999px 0 0 999px}',
       '.dshw_chipNoRecharge .dshw_chipMain{border-radius:999px}',
       '.dshw_chipVertical.dshw_chipNoRecharge .dshw_chipMain{border-radius:7px}',
       '.dshw_recharge{color:var(--dsw-alias-brand-primary,#4aa3ff);border-left:1px solid var(--dsw-alias-border-l2,rgba(0,0,0,.15));padding:0 7px 0 6px;border-radius:0 999px 999px 0}',
-      '.dshw_chipMain:focus-visible,.dshw_recharge:focus-visible,.dshw_btn:focus-visible,.dshw_floatBtn:focus-visible,.dshw_dot:focus-visible{outline:2px solid var(--dsw-alias-brand-primary,#4aa3ff);outline-offset:2px}',
+      '.dshw_gear{border-left:1px solid var(--dsw-alias-border-l2,rgba(0,0,0,.15));padding:0 7px 0 6px;border-radius:0 999px 999px 0}',
+      '.dshw_chipVertical .dshw_gear{display:none}',
+      '.dshw_chipMain:focus-visible,.dshw_recharge:focus-visible,.dshw_gear:focus-visible,.dshw_btn:focus-visible,.dshw_floatBtn:focus-visible,.dshw_dot:focus-visible{outline:2px solid var(--dsw-alias-brand-primary,#4aa3ff);outline-offset:2px}',
       '.dshw_panel{z-index:40;border:1px solid var(--dsw-alias-border-l2,rgba(0,0,0,.15));background:var(--dsw-alias-bg-overlay,#ffffff);box-sizing:border-box;width:min(276px,calc(100vw - 12px));max-height:calc(100vh - 16px);overflow:auto;color:var(--dsw-alias-label-primary,#1f2328);border-radius:8px;flex-direction:column;gap:4px;padding:8px 9px;font-size:12px;display:flex;position:fixed;box-shadow:0 4px 12px #0000004d}',
       '.dshw_panelHeader{min-height:24px;cursor:move;touch-action:none;user-select:none}',
       '.dshw_panelHeader .dshw_btn{cursor:pointer}',
@@ -315,7 +317,7 @@ window.__ModuleLoader__.load({
       // width from the chip, so flex layouts resolve it to min-width (44px)
       // even when the row has room.
       '.dshw_anchorHome.dshw_fit .dshw_chipMain>span:not(.dshw_homePrimary){display:none}',
-      '.dshw_anchorHome.dshw_compact .dshw_chip{width:100%}.dshw_anchorHome.dshw_compact .dshw_chipMain{box-sizing:border-box;width:100%;min-width:0;overflow:hidden;justify-content:center;padding:0 3px}.dshw_anchorHome.dshw_compact .dshw_chipMain>span{display:none}.dshw_anchorHome.dshw_compact .dshw_chipMain>.dshw_homePrimary{display:inline;min-width:0;overflow:hidden;text-overflow:ellipsis}.dshw_anchorHome.dshw_compact .dshw_homePrimaryLabel{display:none}.dshw_anchorHome.dshw_compact .dshw_recharge{display:none}',
+      '.dshw_anchorHome.dshw_compact .dshw_chip{width:100%}.dshw_anchorHome.dshw_compact .dshw_chipMain{box-sizing:border-box;width:100%;min-width:0;overflow:hidden;justify-content:center;padding:0 3px}.dshw_anchorHome.dshw_compact .dshw_chipMain>span{display:none}.dshw_anchorHome.dshw_compact .dshw_chipMain>.dshw_homePrimary{display:inline;min-width:0;overflow:hidden;text-overflow:ellipsis}.dshw_anchorHome.dshw_compact .dshw_homePrimaryLabel{display:none}.dshw_anchorHome.dshw_compact .dshw_recharge{display:none}.dshw_anchorHome.dshw_compact .dshw_gear{display:none}',
       '@media (max-width:420px){.dshw_chipDocked:not(.dshw_chipVertical){max-width:calc(100vw - 4px);font-size:10px}.dshw_chipDocked:not(.dshw_chipVertical) .dshw_chipMain{gap:3px;padding:0 4px}.dshw_chipDocked:not(.dshw_chipVertical) .dshw_recharge{padding:0 4px}}'
     ].join('')
 
@@ -1737,7 +1739,27 @@ window.__ModuleLoader__.load({
           title: 'DeepSeek \u5f00\u653e\u5e73\u53f0 \u00b7 \u5b98\u65b9\u5145\u503c\u9875',
           'aria-label': '\u6253\u5f00 DeepSeek \u5b98\u65b9\u5145\u503c\u9875',
           onClick: onRechargeClick
-        }, '\u2197\u5145') : null)
+        }, '\u2197\u5145') : null,
+        React.createElement('button', {
+          type: 'button',
+          className: 'dshw_gear',
+          title: '\u94b1\u5305\u8bbe\u7f6e \u00b7 \u70b9\u51fb\u6253\u5f00\u8bbe\u7f6e\u9762\u677f',
+          'aria-label': '\u6253\u5f00\u94b1\u5305\u8bbe\u7f6e',
+          'aria-expanded': open,
+          'aria-haspopup': 'dialog',
+          onClick: function () {
+            if (chipDidDragRef.current === true) return
+            requestNotify()
+            if (floated) {
+              setFloated(false)
+              setPanelStyle({ visibility: 'hidden' })
+              setOpen(true)
+              return
+            }
+            if (!open) setPanelStyle({ visibility: 'hidden' })
+            setOpen(!open)
+          }
+        }, '\u2699'))
 
       var chipHost = React.createElement('span', { ref: chipAnchorRef, className: chipDock === 'home' ? 'dshw_anchor dshw_anchorHome' + (homeMode === 'compact' ? ' dshw_compact' : homeMode === 'fit' ? ' dshw_fit' : '') : 'dshw_anchor' }, chip)
       var snapPreviewElement = snapPreview ? React.createElement('div', {

--- a/test/wallet.test.mjs
+++ b/test/wallet.test.mjs
@@ -1454,3 +1454,13 @@ test('activateAccount: missing accounts and refused credential writes fail safel
   // The stored activeId is left untouched on failure.
   assert.equal(mod.activeAccount().id, added.account.id)
 })
+test('chip exposes a settings gear that opens the control panel', () => {
+  const renderer = createHookRenderer()
+  const { exports } = loadClientBundle(renderer.React)
+  const { Component } = walletComponent(exports)
+  const tree = renderer.render(Component, { sessionId: 'session-1' })
+  const gear = findElement(tree, (element) => element.type === 'button' && element.props['aria-label'] === '打开钱包设置')
+  assert.ok(gear, 'the chip must expose a settings entry button beside the recharge control')
+  assert.equal(typeof gear.props.onClick, 'function')
+  assert.equal(gear.props['aria-haspopup'], 'dialog')
+})


### PR DESCRIPTION
## 新增 / Added

- 余额标签右侧新增 ⚙ 设置入口，点击直接打开钱包设置面板（悬浮/极简模式下自动隐藏）/ A ⚙ gear beside the balance chip opens the control panel directly; hidden in vertical and compact layouts
- CHANGELOG 增加 0.2.0 段落（多账户 + 设置入口）/ Release notes for 0.2.0

52/52 tests pass. Verified live on dsh 0.1.0-rc.7.