### PR TITLE
feat: wallet section in the host settings panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project are documented in this file.
 
 - 新增多账户管理与热切换：面板内“账户管理”可添加多个账户（名称 + API Key），切换后无需重启，下一次 LLM 调用即按新账户计费；key 界面掩码显示，余额查询跟随当前账户（contributed in PR #4 by mxchen-xyz）。 / Added multi-account management with hot switching: manage accounts in the panel, and the very next LLM call is billed with the newly activated key — no restart needed; keys stay masked in the UI and balance follows the active account.
 - 余额标签右侧新增 ⚙ 设置入口，点击直接打开钱包设置面板。 / Added a ⚙ settings entry beside the balance chip that opens the control panel directly.
+- 宿主设置面板（视觉工具下方）新增「钱包」设置页：余额、阈值、显示内容、芯片比例、完成提醒与账户管理，与标签面板实时同步。 / Added a 钱包 (Wallet) page to the host settings panel below Visual tools: balance, threshold, visibility, chip scale, completion reminders, and account management, kept in sync with the chip panel.
 
 ## 0.1.5 - 2026-08-18
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -20,6 +20,7 @@ window.__ModuleLoader__.load({
     var DATA_VISIBILITY_KEY = 'dshw-data-visibility-v1'
     var NOTIFY_CONFIG_KEY = 'dshw-completion-notify-v1'
     var NOTIFY_CONFIG_EVENT = 'dshw-completion-notify-change'
+    var SETTINGS_EVENT = 'dshw-settings-change'
     var NOTIFY_LEADER_KEY = 'dshw-completion-notify-leader-v1'
     var PERMANENT_DELETE_KEY = 'dshw-permanent-delete-v1'
     var PERMANENT_DELETE_EVENT = 'dshw-permanent-delete-change'
@@ -770,6 +771,296 @@ window.__ModuleLoader__.load({
       return (counters.input || 0) + (counters.output || 0) + (counters.cacheRead || 0) + (counters.cacheWrite || 0)
     }
 
+    /**
+     * Host settings-panel section: the same wallet controls as the chip panel,
+     * as an independent card. Shares state with the chip through the same
+     * storage keys plus the SETTINGS_EVENT notification, so both surfaces stay
+     * in sync without lifting the chip's internal state.
+     */
+    function WalletSettingsSection(props) {
+      props = props || {}
+      var close = typeof props.close === 'function' ? props.close : null
+      var [snapshot, setSnapshot] = React.useState(null)
+      var [thresholdDraft, setThresholdDraft] = React.useState('')
+      var [thresholdNotice, setThresholdNotice] = React.useState(null)
+      var [accounts, setAccounts] = React.useState(null)
+      var [accountsError, setAccountsError] = React.useState(null)
+      var [accountNotice, setAccountNotice] = React.useState(null)
+      var [nameDraft, setNameDraft] = React.useState('')
+      var [keyDraft, setKeyDraft] = React.useState('')
+      var [switchingId, setSwitchingId] = React.useState(null)
+      var [visibility, setVisibility] = React.useState(function () {
+        try {
+          var saved = compatibility.storage.getItem(DATA_VISIBILITY_KEY)
+          return saved === null ? normalizeDataVisibility(null) : normalizeDataVisibility(JSON.parse(saved))
+        } catch (e) { return normalizeDataVisibility(null) }
+      })
+      var [scale, setScale] = React.useState(function () {
+        try { return normalizeChipScale(compatibility.storage.getItem(CHIP_SCALE_KEY)) } catch (e) { return 1 }
+      })
+      var [scaleMax, setScaleMax] = React.useState(125)
+      var [notifyEnabled, setNotifyEnabled] = React.useState(function () { return readNotifyConfig().enabled })
+      var [notifyTimeout, setNotifyTimeout] = React.useState(function () {
+        var cfg = readNotifyConfig()
+        return cfg.autoCloseMs === null ? 'keep' : String(Math.round(cfg.autoCloseMs / 1000))
+      })
+
+      React.useEffect(function () {
+        var stopped = false
+        function refresh() {
+          fetch('/api/wallet/snapshot').then(function (resp) { return resp.json() }).then(function (json) {
+            if (!stopped && json && json.ok) {
+              setSnapshot(json)
+              setThresholdDraft(json.threshold !== undefined && json.threshold !== null ? json.threshold.toFixed(2) : '')
+            }
+          }).catch(function () { /* ignore */ })
+        }
+        refresh()
+        fetch('/api/wallet/accounts').then(function (resp) { return resp.json() }).then(function (json) {
+          if (!stopped && json && json.ok) setAccounts(json)
+        }).catch(function () { if (!stopped) setAccountsError('\u8d26\u6237\u63a5\u53e3\u4e0d\u53ef\u7528') })
+        try {
+          var savedLayout = compatibility.storage.getItem(CHIP_LAYOUT_KEY)
+          var dock = savedLayout === null ? 'home' : normalizeChipLayout(JSON.parse(savedLayout)).dock
+          setScaleMax(dock === 'home' ? 120 : 125)
+        } catch (e) { /* ignore */ }
+        return function () { stopped = true }
+      }, [])
+
+      function persistVisibility(next) {
+        next = normalizeDataVisibility(next)
+        setVisibility(next)
+        try { compatibility.storage.setItem(DATA_VISIBILITY_KEY, JSON.stringify(next)) } catch (e) { /* ignore */ }
+        compatibility.dispatch(SETTINGS_EVENT)
+      }
+
+      function persistScale(next) {
+        next = normalizeChipScale(next)
+        if (next > scaleMax / 100) next = scaleMax / 100
+        setScale(next)
+        try { compatibility.storage.setItem(CHIP_SCALE_KEY, String(next)) } catch (e) { /* ignore */ }
+        compatibility.dispatch(SETTINGS_EVENT)
+      }
+
+      function persistNotify(enabled, timeout) {
+        var autoCloseMs = timeout === 'keep' ? null : Number.parseInt(timeout, 10) * 1000
+        if (!Number.isFinite(autoCloseMs) && timeout !== 'keep') autoCloseMs = 10000
+        try {
+          compatibility.storage.setItem(NOTIFY_CONFIG_KEY, JSON.stringify({ enabled: enabled, autoCloseMs: autoCloseMs }))
+        } catch (e) { /* ignore */ }
+        setNotifyEnabled(enabled)
+        setNotifyTimeout(timeout)
+        compatibility.dispatch(NOTIFY_CONFIG_EVENT)
+      }
+
+      function saveThreshold() {
+        var value = Number.parseFloat(thresholdDraft)
+        if (!Number.isFinite(value)) return
+        value = Math.min(100000, Math.max(0, Math.round(value * 100) / 100))
+        fetch('/api/wallet/threshold', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ threshold: value })
+        }).then(function (resp) { return resp.json() }).then(function (json) {
+          if (json && json.ok) {
+            setThresholdDraft(json.threshold.toFixed(2))
+            setThresholdNotice('\u5df2\u4fdd\u5b58')
+            if (snapshot) { snapshot.threshold = json.threshold; setSnapshot(Object.assign({}, snapshot)) }
+          }
+        }).catch(function () { setThresholdNotice('\u4fdd\u5b58\u5931\u8d25') })
+      }
+
+      function reloadAccounts() {
+        fetch('/api/wallet/accounts').then(function (resp) { return resp.json() }).then(function (json) {
+          if (json && json.ok) { setAccounts(json); setAccountsError(null) }
+        }).catch(function () { /* ignore */ })
+        fetch('/api/wallet/snapshot').then(function (resp) { return resp.json() }).then(function (json) {
+          if (json && json.ok) setSnapshot(json)
+        }).catch(function () { /* ignore */ })
+      }
+
+      function addAccount() {
+        var name = nameDraft.trim()
+        var key = keyDraft.trim()
+        if (!name || !key) return
+        fetch('/api/wallet/accounts', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ name: name, apiKey: key })
+        }).then(function (resp) { return resp.json() }).then(function (json) {
+          if (json && json.ok) {
+            setNameDraft(''); setKeyDraft('')
+            setAccountNotice(json.synced ? '\u5df2\u6dfb\u52a0\u5e76\u8bbe\u4e3a\u5f53\u524d\u8d26\u6237' : '\u5df2\u6dfb\u52a0')
+            reloadAccounts()
+          } else {
+            setAccountNotice(json && json.error ? String(json.error) : '\u6dfb\u52a0\u5931\u8d25')
+          }
+        }).catch(function () { setAccountNotice('\u6dfb\u52a0\u5931\u8d25') })
+      }
+
+      function activateAccount(id, name) {
+        if (!window.confirm('\u5207\u6362\u5230\u300c' + name + '\u300d\uff1f\u540e\u7eed LLM \u8bf7\u6c42\u5c06\u6309\u8be5\u8d26\u6237\u8ba1\u8d39\u3002')) return
+        setSwitchingId(id)
+        fetch('/api/wallet/accounts/activate', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ id: id })
+        }).then(function (resp) { return resp.json() }).then(function (json) {
+          setSwitchingId(null)
+          setAccountNotice(json && json.ok ? '\u5df2\u5207\u6362\u5230\u300c' + name + '\u300d' : (json && json.error ? String(json.error) : '\u5207\u6362\u5931\u8d25'))
+          reloadAccounts()
+        }).catch(function () { setSwitchingId(null); setAccountNotice('\u5207\u6362\u5931\u8d25') })
+      }
+
+      function removeAccount(id, name) {
+        if (!window.confirm('\u5220\u9664\u8d26\u6237\u300c' + name + '\u300d\uff1f')) return
+        fetch('/api/wallet/accounts/remove', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ id: id })
+        }).then(function (resp) { return resp.json() }).then(function (json) {
+          setAccountNotice(json && json.ok ? '\u5df2\u5220\u9664' : '\u5220\u9664\u5931\u8d25')
+          reloadAccounts()
+        }).catch(function () { setAccountNotice('\u5220\u9664\u5931\u8d25') })
+      }
+
+      var bal = snapshot && snapshot.balance ? snapshot.balance : null
+      var balanceText = bal && bal.total !== null && bal.total !== undefined ? fmtCurrency(bal.total, bal.currency) : '--'
+      var activeName = snapshot && snapshot.accounts && snapshot.accounts.activeName ? snapshot.accounts.activeName : null
+      var list = accounts && accounts.accounts ? accounts.accounts : []
+      var rows = []
+
+      rows.push(React.createElement('div', { key: 'bal', className: 'dshw_row' },
+        React.createElement('span', { className: 'dshw_muted' }, '\u4f59\u989d'),
+        React.createElement('span', null, balanceText),
+        React.createElement('button', {
+          type: 'button', className: 'dshw_btn', style: { padding: '2px 8px' },
+          onClick: reloadAccounts
+        }, '\u5237\u65b0')))
+
+      rows.push(React.createElement('div', { key: 'th', className: 'dshw_row' },
+        React.createElement('span', { className: 'dshw_muted' }, '\u4f59\u989d\u63d0\u9192\u9608\u503c (\u00a5, 0=\u5173)'),
+        React.createElement('input', {
+          className: 'dshw_input', type: 'number', min: '0', step: '0.01',
+          style: { width: '76px' },
+          value: thresholdDraft,
+          'aria-label': '\u4f59\u989d\u63d0\u9192\u9608\u503c\uff08CNY\uff09',
+          onInput: function (event) { setThresholdDraft(event.target.value) },
+          onChange: function (event) { setThresholdDraft(event.target.value) }
+        }),
+        React.createElement('button', { type: 'button', className: 'dshw_btn', onClick: saveThreshold }, '\u4fdd\u5b58'),
+        thresholdNotice ? React.createElement('span', { key: 'tn', className: 'dshw_muted' }, thresholdNotice) : null))
+
+      rows.push(React.createElement('div', { key: 'vis', className: 'dshw_row' },
+        React.createElement('span', { className: 'dshw_muted' }, '\u663e\u793a\u5185\u5bb9'),
+        React.createElement('label', { className: 'dshw_visibilityControl' },
+          React.createElement('input', {
+            type: 'checkbox',
+            checked: visibility.official,
+            onChange: function (event) { persistVisibility({ official: event.target.checked, third: visibility.third }) }
+          }), '\u5b98\u65b9\u6570\u636e'),
+        React.createElement('label', { className: 'dshw_visibilityControl' },
+          React.createElement('input', {
+            type: 'checkbox',
+            checked: visibility.third,
+            onChange: function (event) { persistVisibility({ official: visibility.official, third: event.target.checked }) }
+          }), '\u7b2c\u4e09\u65b9 token')))
+
+      rows.push(React.createElement('div', { key: 'sc', className: 'dshw_row' },
+        React.createElement('span', { className: 'dshw_muted' }, '\u82af\u7247\u6bd4\u4f8b'),
+        React.createElement('span', { className: 'dshw_scaleControl' },
+          React.createElement('input', {
+            className: 'dshw_scaleInput', type: 'range', min: '75', max: String(scaleMax), step: '5',
+            value: String(Math.round(scale * 100)),
+            'aria-label': '\u94b1\u5305\u82af\u7247\u6bd4\u4f8b',
+            onInput: function (event) { persistScale(Number.parseFloat(event.target.value) / 100) },
+            onChange: function (event) { persistScale(Number.parseFloat(event.target.value) / 100) }
+          }),
+          React.createElement('span', { className: 'dshw_scaleValue' }, Math.round(scale * 100) + '%'))))
+
+      rows.push(React.createElement('div', { key: 'nf', className: 'dshw_row' },
+        React.createElement('span', { className: 'dshw_muted' }, '\u5b8c\u6210\u63d0\u9192'),
+        React.createElement('label', { className: 'dshw_visibilityControl' },
+          React.createElement('input', {
+            type: 'checkbox',
+            checked: notifyEnabled,
+            onChange: function (event) { persistNotify(event.target.checked, notifyTimeout) }
+          }), '\u5f00\u542f'),
+        React.createElement('select', {
+          className: 'dshw_select', style: { width: '132px' },
+          'aria-label': '\u63d0\u9192\u81ea\u52a8\u5173\u95ed\u65f6\u95f4',
+          value: notifyTimeout,
+          onChange: function (event) { persistNotify(notifyEnabled, event.target.value) }
+        },
+          React.createElement('option', { value: 'keep' }, '\u4e00\u76f4\u4fdd\u7559\uff0c\u624b\u52a8\u5173\u95ed'),
+          React.createElement('option', { value: '5' }, '5 \u79d2'),
+          React.createElement('option', { value: '10' }, '10 \u79d2'),
+          React.createElement('option', { value: '30' }, '30 \u79d2'),
+          React.createElement('option', { value: '60' }, '60 \u79d2'))))
+
+      rows.push(React.createElement('div', { key: 'acc-t', className: 'dshw_title', style: { marginTop: '6px' } }, '\u8d26\u6237\u7ba1\u7406'))
+      rows.push(React.createElement('div', { key: 'acc-cur', className: 'dshw_row' },
+        React.createElement('span', { className: 'dshw_muted' }, '\u5f53\u524d\u8d26\u6237'),
+        React.createElement('span', null, activeName ? activeName + ' \u00b7 LLM \u8ba1\u8d39' : '\u8ddf\u968f\u7cfb\u7edf Key')))
+      if (accountsError) {
+        rows.push(React.createElement('div', { key: 'acc-e', className: 'dshw_muted' }, accountsError))
+      } else if (list.length === 0) {
+        rows.push(React.createElement('div', { key: 'acc-none', className: 'dshw_muted' }, '\u6682\u65e0\u8d26\u6237\uff0c\u6dfb\u52a0\u540e\u5c06\u81ea\u52a8\u6210\u4e3a\u5f53\u524d\u8d26\u6237'))
+      }
+      list.forEach(function (acc) {
+        rows.push(React.createElement('div', { key: 'acc-' + acc.id, className: 'dshw_row' },
+          React.createElement('span', {
+            className: 'dshw_title',
+            style: { flex: '1 1 auto', minWidth: '0', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }
+          }, acc.name),
+          React.createElement('span', { className: 'dshw_muted' }, acc.maskedKey),
+          acc.active
+            ? React.createElement('span', { key: 'a', className: 'dshw_muted' }, '\u5f53\u524d')
+            : React.createElement('button', {
+                key: 's', type: 'button', className: 'dshw_btn', style: { padding: '2px 8px' },
+                disabled: switchingId !== null,
+                onClick: function () { activateAccount(acc.id, acc.name) }
+              }, switchingId === acc.id ? '\u2026' : '\u5207\u6362'),
+          React.createElement('button', {
+            key: 'r', type: 'button', className: 'dshw_btn', style: { padding: '2px 6px' },
+            onClick: function () { removeAccount(acc.id, acc.name) }
+          }, '\u00d7')))
+      })
+      rows.push(React.createElement('div', { key: 'acc-add', className: 'dshw_row', style: { gap: '4px' } },
+        React.createElement('input', {
+          className: 'dshw_input', style: { width: '84px' },
+          placeholder: '\u540d\u79f0', 'aria-label': '\u540d\u79f0',
+          value: nameDraft,
+          onInput: function (event) { setNameDraft(event.target.value) },
+          onChange: function (event) { setNameDraft(event.target.value) }
+        }),
+        React.createElement('input', {
+          className: 'dshw_input', style: { flex: '1 1 auto', minWidth: '60px' },
+          placeholder: 'sk-...', 'aria-label': 'API Key',
+          value: keyDraft,
+          onInput: function (event) { setKeyDraft(event.target.value) },
+          onChange: function (event) { setKeyDraft(event.target.value) }
+        }),
+        React.createElement('button', { type: 'button', className: 'dshw_btn', onClick: addAccount }, '\u6dfb\u52a0')))
+      if (accountNotice) {
+        rows.push(React.createElement('div', { key: 'acc-n', className: 'dshw_muted' }, accountNotice))
+      }
+
+      rows.push(React.createElement('div', { key: 'acts', className: 'dshw_row', style: { marginTop: '6px' } },
+        React.createElement('button', {
+          type: 'button', className: 'dshw_btn',
+          onClick: function () {
+            fetch('/api/wallet/refresh', { method: 'POST' }).then(reloadAccounts).catch(function () { /* ignore */ })
+          }
+        }, '\u5237\u65b0\u4f59\u989d'),
+        React.createElement('button', {
+          type: 'button', className: 'dshw_btn',
+          onClick: function () { if (close) close(); window.open('https://platform.deepseek.com/top_up', '_blank', 'noopener') }
+        }, '\u2197 \u53bb\u5b98\u65b9\u5145\u503c')))
+
+      return React.createElement('div', { className: 'dshw_settingsSection', style: { display: 'flex', flexDirection: 'column', gap: '6px', fontSize: '12px', color: 'var(--dsw-alias-label-primary,#1f2328)' } }, rows)
+    }
+
     function WalletChip(props) {
       props = props || {}
       var sessionId = props.sessionId
@@ -836,6 +1127,18 @@ window.__ModuleLoader__.load({
         } catch (e) { return normalizeDataVisibility(null) }
       })
       var [notifyConfig, setNotifyConfig] = React.useState(readNotifyConfig)
+      React.useEffect(function () {
+        function refreshVisibilityAndScale() {
+          try {
+            var savedVisibility = compatibility.storage.getItem(DATA_VISIBILITY_KEY)
+            setDataVisibility(savedVisibility === null ? normalizeDataVisibility(null) : normalizeDataVisibility(JSON.parse(savedVisibility)))
+          } catch (e) { /* ignore */ }
+          try { setChipScale(normalizeChipScale(compatibility.storage.getItem(CHIP_SCALE_KEY))) } catch (e) { /* ignore */ }
+        }
+        window.addEventListener(SETTINGS_EVENT, refreshVisibilityAndScale)
+        return function () { window.removeEventListener(SETTINGS_EVENT, refreshVisibilityAndScale) }
+      }, [])
+
       React.useEffect(function () {
         function refreshNotifyConfig() { setNotifyConfig(readNotifyConfig()) }
         window.addEventListener(NOTIFY_CONFIG_EVENT, refreshNotifyConfig)
@@ -2092,6 +2395,21 @@ window.__ModuleLoader__.load({
           }, WalletChip)
         }, 'dsh-wallet: chip registration')
       })
+      // Host settings panel section (dsh rc.7 settings cards): order 40 sits
+      // right below the vision-toolkit section (order 30) contributed by
+      // another plugin. Registered only when the host exposes the slots API
+      // root, so older hosts without settings cards keep loading the wallet.
+      if (ctx.slots && typeof ctx.slots.inject === 'function') {
+        ctx.slots.inject('settings.section', function () {
+          return ctx.slots.register({
+            name: 'settings.section',
+            id: 'wallet',
+            order: 40,
+            label: function () { return '\u94b1\u5305' },
+            inject: function () { return {} }
+          }, WalletSettingsSection)
+        })
+      }
     }
 
     exports.apply = apply

--- a/test/wallet.test.mjs
+++ b/test/wallet.test.mjs
@@ -1464,3 +1464,17 @@ test('chip exposes a settings gear that opens the control panel', () => {
   assert.equal(typeof gear.props.onClick, 'function')
   assert.equal(gear.props['aria-haspopup'], 'dialog')
 })
+
+test('plugin registers a host settings-panel section below the visual tools', () => {
+  const source = readProjectFile('lib/client.js')
+  assert.match(source, /ctx\.slots\.inject\('settings\.section'/, 'the wallet must register a settings-panel section through the host slots API')
+  assert.match(source, /id: 'wallet',\s*\r?\n\s*order: 40/, 'the section must use order 40, right below the vision-toolkit section at 30')
+  assert.match(source, /WalletSettingsSection/, 'the settings section component must exist')
+  const renderer = createHookRenderer()
+  const { exports } = loadClientBundle(renderer.React)
+  const { Component } = walletComponent(exports)
+  const tree = renderer.render(Component, { sessionId: 'session-1' })
+  // WalletChip 仍正常渲染（回归）
+  const chip = findElement(tree, (element) => element.props && element.props['aria-label'] === 'DeepSeek 钱包')
+  assert.ok(chip, 'the composer chip must keep rendering')
+})


### PR DESCRIPTION
## 新增 / Added

- 宿主设置面板新增「钱包」设置页（视觉工具下方）：余额、提醒阈值、显示内容、芯片比例、完成提醒、账户管理 / A 钱包 settings page in the host settings panel (below Visual tools): balance, threshold, visibility, chip scale, reminders, and account management
- 与标签面板通过同一存储键 + 事件实时双向同步 / Two-way live sync with the chip panel via shared storage keys and an event
- 旧版宿主（无 settings-cards API）自动跳过注册 / Registration is guarded on older hosts

53/53 tests pass. Verified live on dsh 0.1.0-rc.7.