### PR TITLE
feat: restyle the wallet panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project are documented in this file.
 ## 0.2.0 - 2026-08-18
 
 - 新增多账户管理与热切换：面板内“账户管理”可添加多个账户（名称 + API Key），切换后无需重启，下一次 LLM 调用即按新账户计费；key 界面掩码显示，余额查询跟随当前账户（contributed in PR #4 by mxchen-xyz）。 / Added multi-account management with hot switching: manage accounts in the panel, and the very next LLM call is billed with the newly activated key — no restart needed; keys stay masked in the UI and balance follows the active account.
+- 面板视觉重做：余额横排摘要卡、设置合并为分组卡片（胶囊开关、行内滑块、阈值保存贴边）、账户列表限高两行滚动、主操作并列与安静的清除入口。 / Restyled the panel: horizontal balance summary card, grouped settings card (chip toggles, inline slider, threshold save inline), two-row scrollable account list, and paired primary actions with a quiet destructive entry.
 - 宿主设置面板（视觉工具下方）新增「钱包」设置页：余额、阈值、显示内容、芯片比例、完成提醒与账户管理，与标签面板实时同步。 / Added a 钱包 (Wallet) page to the host settings panel below Visual tools: balance, threshold, visibility, chip scale, completion reminders, and account management, kept in sync with the chip panel.
 
 ## 0.1.5 - 2026-08-18

--- a/lib/client.js
+++ b/lib/client.js
@@ -296,6 +296,34 @@ window.__ModuleLoader__.load({
       '.dshw_select{background:var(--dsw-alias-bg-layer-1,#fff);border:1px solid var(--dsw-alias-border-l2,rgba(0,0,0,.15));color:var(--dsw-alias-label-primary,#1f2328);border-radius:5px;padding:2px 4px;font-size:12px}',
       '.dshw_btn{border:1px solid var(--dsw-alias-border-l2,rgba(0,0,0,.15));background:transparent;color:var(--dsw-alias-label-primary,#1f2328);border-radius:5px;padding:2px 6px;font-size:12px;cursor:pointer}',
       '.dshw_btnPrimary{background:var(--dsw-alias-brand-primary,#4aa3ff);border-color:transparent;color:var(--dsw-alias-label-primary-foreground,#ffffff)}',
+      // ---- v0.2 panel restyle: balance card, settings card, account scroll ----
+      '.dshw_balanceCard{margin:2px 0 2px;padding:8px 10px;border:1px solid var(--dsw-alias-border-l2,rgba(0,0,0,.15));border-radius:8px;background:var(--dsw-alias-bg-l1,rgba(127,127,127,.06))}',
+      '.dshw_balLine{display:flex;align-items:center;gap:7px;white-space:nowrap}',
+      '.dshw_balNum{font-size:18px;font-weight:650;line-height:1.1;letter-spacing:-.01em;font-variant-numeric:tabular-nums}',
+      '.dshw_balWarn{display:inline-flex;align-items:center;gap:4px;padding:1px 6px;border-radius:999px;background:var(--dsw-alias-state-error-soft,rgba(229,83,75,.12));color:var(--dsw-alias-state-error-primary,#e5534b);font-size:10px;font-weight:500;line-height:16px;white-space:nowrap}',
+      '.dshw_balWarn::before{content:"";width:5px;height:5px;border-radius:50%;background:var(--dsw-alias-state-error-primary,#e5534b);animation:dshwPulse 1.8s infinite}',
+      '.dshw_balFill{flex:1}',
+      '.dshw_balSession{text-align:right;white-space:nowrap}',
+      '.dshw_balSession .dshw_muted{margin-right:5px}',
+      '.dshw_balSessionNum{font-size:13px;font-weight:600;font-variant-numeric:tabular-nums}',
+      '.dshw_balSub{margin-top:4px;font-size:11px;color:var(--dsw-alias-label-secondary,rgba(31,35,40,.68));display:flex;align-items:center;gap:7px;white-space:nowrap}',
+      '.dshw_balSub .dshw_balDot{color:var(--dsw-alias-label-quaternary,rgba(31,35,40,.45))}',
+      '.dshw_setCard{border:1px solid var(--dsw-alias-border-l2,rgba(0,0,0,.15));border-radius:8px;background:var(--dsw-alias-bg-elevated,transparent);overflow:hidden;margin:2px 0}',
+      '.dshw_setCell{display:flex;align-items:center;gap:8px;padding:6px 9px;min-height:34px}',
+      '.dshw_setCell+.dshw_setCell{border-top:1px solid var(--dsw-alias-border-l1,rgba(0,0,0,.08))}',
+      '.dshw_setCell:hover{background:var(--dsw-alias-bg-l1,rgba(127,127,127,.06))}',
+      '.dshw_setCell .dshw_scaleControl{min-width:0;flex:1;justify-content:flex-end}',
+      '.dshw_chipToggle{display:inline-flex;align-items:center;gap:6px;height:24px;padding:0 9px;border:1px solid var(--dsw-alias-border-l2,rgba(0,0,0,.15));border-radius:999px;background:transparent;font-size:11.5px;color:var(--dsw-alias-label-secondary,rgba(31,35,40,.68));cursor:pointer;white-space:nowrap;transition:color .12s,border-color .12s,background-color .12s}',
+      '.dshw_chipToggle:hover{border-color:var(--dsw-alias-brand-primary,#4aa3ff)}',
+      '.dshw_chipToggle input{margin:0;accent-color:var(--dsw-alias-brand-primary,#4aa3ff)}',
+      '.dshw_acctScroll{border:1px solid var(--dsw-alias-border-l2,rgba(0,0,0,.15));border-radius:8px;overflow-y:auto;max-height:88px;scrollbar-width:thin;scrollbar-color:var(--dsw-alias-border-l3,rgba(0,0,0,.25)) transparent;margin:2px 0}',
+      '.dshw_acctScroll::-webkit-scrollbar{width:6px}',
+      '.dshw_acctScroll::-webkit-scrollbar-thumb{background:var(--dsw-alias-border-l3,rgba(0,0,0,.25));border-radius:3px}',
+      '.dshw_acctScroll .dshw_row{padding:5px 8px}',
+      '.dshw_acctMore{display:flex;justify-content:flex-end;font-size:10.5px;color:var(--dsw-alias-label-quaternary,rgba(31,35,40,.45));margin-top:3px}',
+      '.dshw_actionRow{display:grid;grid-template-columns:1fr 1fr;gap:6px;margin:2px 0}',
+      '.dshw_textDanger{display:inline-flex;align-items:center;gap:5px;height:22px;padding:0 4px;border:none;background:transparent;font:inherit;font-size:11px;color:var(--dsw-alias-label-quaternary,rgba(31,35,40,.45));cursor:pointer;border-radius:4px;transition:color .12s,background-color .12s}',
+      '.dshw_textDanger:hover{color:var(--dsw-alias-state-error-primary,#e5534b);background:var(--dsw-alias-state-error-soft,rgba(229,83,75,.12))}',
       '.dshw_overlay{position:fixed;inset:0;background:var(--dsw-alias-bg-mask-drop,rgba(0,0,0,.55));display:flex;align-items:center;justify-content:center;z-index:100}',
       '.dshw_overlayBox{background:var(--dsw-alias-bg-overlay,#ffffff);border:1px solid var(--dsw-alias-border-l2,rgba(0,0,0,.15));color:var(--dsw-alias-label-primary,#1f2328);border-radius:8px;padding:14px 18px;width:min(320px,calc(100vw - 32px));box-sizing:border-box;font-size:13px;line-height:1.7}',
       '.dshw_overlayRow{margin-top:10px;display:flex;gap:8px;justify-content:flex-end}',
@@ -1005,7 +1033,7 @@ window.__ModuleLoader__.load({
       } else if (list.length === 0) {
         rows.push(React.createElement('div', { key: 'acc-none', className: 'dshw_muted' }, '\u6682\u65e0\u8d26\u6237\uff0c\u6dfb\u52a0\u540e\u5c06\u81ea\u52a8\u6210\u4e3a\u5f53\u524d\u8d26\u6237'))
       }
-      list.forEach(function (acc) {
+          list.forEach(function (acc) {
         rows.push(React.createElement('div', { key: 'acc-' + acc.id, className: 'dshw_row' },
           React.createElement('span', {
             className: 'dshw_title',
@@ -1872,6 +1900,7 @@ window.__ModuleLoader__.load({
             children.push(React.createElement('div', { key: 'none', className: 'dshw_muted' },
               '\u6682\u65e0\u8d26\u6237\uff0c\u6dfb\u52a0\u540e\u5c06\u81ea\u52a8\u6210\u4e3a\u5f53\u524d\u8d26\u6237'))
           }
+          var acctRows = []
           list.forEach(function (acc) {
             var rowChildren = []
             rowChildren.push(React.createElement('span', {
@@ -1899,8 +1928,12 @@ window.__ModuleLoader__.load({
               style: { padding: '2px 6px' },
               onClick: function () { removeAccount(acc.id, acc.name) }
             }, '\u00d7'))
-            children.push(React.createElement('div', { key: acc.id, className: 'dshw_row' }, rowChildren))
+            acctRows.push(React.createElement('div', { key: acc.id, className: 'dshw_row', style: { margin: 0 } }, rowChildren))
           })
+          if (acctRows.length > 0) {
+            children.push(React.createElement('div', { key: 'scroll', className: 'dshw_acctScroll' }, acctRows))
+            if (acctRows.length > 2) children.push(React.createElement('div', { key: 'more', className: 'dshw_acctMore' }, '共 ' + acctRows.length + ' 个账户，滑动查看更多'))
+          }
           children.push(React.createElement('div', { key: 'add', className: 'dshw_row', style: { gap: '4px' } },
             React.createElement('input', {
               className: 'dshw_input',
@@ -2179,7 +2212,7 @@ window.__ModuleLoader__.load({
             React.createElement('option', { value: '30' }, '30 秒'),
             React.createElement('option', { value: '60' }, '60 秒'))))
 
-      var permanentDeleteControl = React.createElement('div', { className: 'dshw_row' },
+      var permanentDeleteControl = React.createElement('div', { className: 'dshw_setCell', style: { border: 'none', padding: '0 9px', minHeight: '30px' } },
         React.createElement('span', { className: 'dshw_muted' }, '永久删除会话'),
         React.createElement('label', { className: 'dshw_check' },
           React.createElement('input', {
@@ -2231,6 +2264,108 @@ window.__ModuleLoader__.load({
           }
         }, '－ 最小化'))
 
+      // Balance summary as one compact horizontal card: hero figure, optional
+      // low-balance pill, inline session cost; breakdown on a quiet sub-line.
+      function balanceCard() {
+        if (!bal.available || !bal.balances || bal.balances.length === 0) {
+          return React.createElement('div', { className: 'dshw_balanceCard' },
+            React.createElement('div', { className: 'dshw_muted' }, bal.error ? ('\u4f59\u989d\u4e0d\u53ef\u7528: ' + bal.error) : '\u4f59\u989d\u67e5\u8be2\u4e2d\u2026'))
+        }
+        var first = bal.balances[0]
+        var others = bal.balances.slice(1)
+        var subParts = [
+          React.createElement('span', { key: 'top' }, '\u5145\u503c ' + fmtCurrency(first.topped_up_balance, first.currency)),
+          React.createElement('span', { key: 'd1', className: 'dshw_balDot' }, '\u00b7'),
+          React.createElement('span', { key: 'grt' }, '\u8d60\u9001 ' + fmtCurrency(first.granted_balance, first.currency))
+        ]
+        others.forEach(function (info, i) {
+          subParts.push(React.createElement('span', { key: 'd' + i, className: 'dshw_balDot' }, '\u00b7'))
+          subParts.push(React.createElement('span', { key: 'x' + i }, info.currency + ' ' + fmtCurrency(info.total_balance, info.currency)))
+        })
+        return React.createElement('div', { className: 'dshw_balanceCard' },
+          React.createElement('div', { className: 'dshw_balLine' },
+            React.createElement('span', { className: 'dshw_muted' }, '\u4f59\u989d'),
+            React.createElement('span', { className: 'dshw_balNum' }, fmtCurrency(first.total_balance, first.currency)),
+            low ? React.createElement('span', { className: 'dshw_balWarn', title: '\u4f4e\u4e8e\u63d0\u9192\u9608\u503c \u00a5' + (snapshot.threshold !== undefined ? snapshot.threshold : '') }, '\u4f59\u989d\u504f\u4f4e') : null,
+            React.createElement('span', { className: 'dshw_balFill' }),
+            React.createElement('span', { className: 'dshw_balSession' },
+              React.createElement('span', { className: 'dshw_muted' }, '\u672c\u4f1a\u8bdd'),
+              React.createElement('span', { className: 'dshw_balSessionNum' }, official.cost === null ? '--' : fmtCurrency(official.cost, 'CNY')))),
+          React.createElement('div', { className: 'dshw_balSub' }, subParts))
+      }
+
+      // All controls in one bordered card with compact rows; the threshold
+      // input carries its own save button so the action row stays two items.
+      function settingsCard() {
+        var cells = []
+        cells.push(React.createElement('div', { key: 'vis', className: 'dshw_setCell' },
+          React.createElement('span', { className: 'dshw_muted' }, '\u663e\u793a\u5185\u5bb9'),
+          React.createElement('span', { className: 'dshw_balFill' }),
+          React.createElement('label', { className: 'dshw_chipToggle' },
+            React.createElement('input', {
+              type: 'checkbox',
+              checked: showOfficial,
+              disabled: showOfficial && !showThird,
+              'aria-label': '显示官方数据',
+              onChange: function (event) { saveDataVisibility({ official: event.target.checked, third: showThird }) }
+            }),
+            React.createElement('span', null, '\u5b98\u65b9')),
+          React.createElement('label', { className: 'dshw_chipToggle' },
+            React.createElement('input', {
+              type: 'checkbox',
+              checked: showThird,
+              disabled: showThird && !showOfficial,
+              'aria-label': '显示第三方 token',
+              onChange: function (event) { saveDataVisibility({ official: showOfficial, third: event.target.checked }) }
+            }),
+            React.createElement('span', null, '\u7b2c\u4e09\u65b9'))))
+        cells.push(React.createElement('div', { key: 'sc', className: 'dshw_setCell' }, scaleControl))
+        cells.push(React.createElement('div', { key: 'nf', className: 'dshw_setCell' },
+          React.createElement('span', { className: 'dshw_muted' }, '\u5b8c\u6210\u63d0\u9192'),
+          React.createElement('span', { className: 'dshw_balFill' }),
+          React.createElement('span', { className: 'dshw_visibilityControl' },
+            React.createElement('label', { className: 'dshw_check' },
+              React.createElement('input', {
+                type: 'checkbox',
+                checked: notifyConfig.enabled,
+                'aria-label': '开启对话完成后提醒',
+                onChange: function (event) {
+                  var enabled = event.target.checked
+                  saveNotifyConfig({ enabled: enabled, timeout: notifyConfig.timeout })
+                  if (enabled) requestNotify()
+                }
+              }),
+              React.createElement('span', null, '\u5f00\u542f')),
+            React.createElement('select', {
+              className: 'dshw_select',
+              value: String(notifyConfig.timeout),
+              disabled: !notifyConfig.enabled,
+              'aria-label': '提醒自动关闭时间',
+              onChange: function (event) {
+                saveNotifyConfig({ enabled: notifyConfig.enabled, timeout: Number.parseInt(event.target.value, 10) })
+              }
+            },
+              React.createElement('option', { value: '0' }, '\u4e00\u76f4\u4fdd\u7559'),
+              React.createElement('option', { value: '5' }, '5 \u79d2'),
+              React.createElement('option', { value: '10' }, '10 \u79d2'),
+              React.createElement('option', { value: '30' }, '30 \u79d2'),
+              React.createElement('option', { value: '60' }, '60 \u79d2')))))
+        cells.push(permanentDeleteControl === null ? null : React.createElement('div', { key: 'pd', className: 'dshw_setCell' }, permanentDeleteControl))
+        if (showOfficial) {
+          cells.push(React.createElement('div', { key: 'th', className: 'dshw_setCell' },
+            React.createElement('span', { className: 'dshw_muted' }, '\u4f59\u989d\u9608\u503c'),
+            React.createElement('span', { className: 'dshw_balFill' }),
+            thresholdInput,
+            React.createElement('button', {
+              type: 'button',
+              className: 'dshw_btn',
+              style: { height: '24px', padding: '0 12px', fontSize: '11.5px' },
+              onClick: saveThreshold
+            }, '\u4fdd\u5b58')))
+        }
+        return React.createElement('div', { className: 'dshw_setCard' }, cells)
+      }
+
       var panel = React.createElement('div', {
         ref: panelRef,
         className: 'dshw_panel',
@@ -2242,40 +2377,33 @@ window.__ModuleLoader__.load({
         floatBtnRow,
         showOfficial ? React.createElement(React.Fragment, null,
           React.createElement('div', { className: 'dshw_title' }, '\u5b98\u65b9 DeepSeek'),
-          balanceRows,
-          officialRows,
+          balanceCard(),
+          official.tokens ? React.createElement('div', { key: 'o-t', className: 'dshw_row' },
+            React.createElement('span', { className: 'dshw_muted' }, '\u5b98\u65b9 token'),
+            React.createElement('span', null, '\u8f93\u5165 ' + fmtTokens(official.tokens.input) + ' \u00b7 \u7f13\u5b58\u8bfb ' + fmtTokens(official.tokens.cacheRead) + ' \u00b7 \u8f93\u51fa ' + fmtTokens(official.tokens.output))) : null,
           React.createElement('div', { className: 'dshw_divider' })) : null,
         showThird ? React.createElement(React.Fragment, null,
           React.createElement('div', { className: 'dshw_title' }, '\u7b2c\u4e09\u65b9\u5408\u8ba1'),
           thirdRows,
           React.createElement('div', { className: 'dshw_divider' })) : null,
-        visibilityControl,
-        scaleControl,
-        notifyControl,
-        permanentDeleteControl,
+        settingsCard(),
         showOfficial ? React.createElement(React.Fragment, null,
-          React.createElement('div', { className: 'dshw_row' },
-            React.createElement('span', { className: 'dshw_muted' }, '\u4f59\u989d\u63d0\u9192\u9608\u503c (\u00a5, 0=\u5173)'),
-            thresholdInput),
-          React.createElement('div', { className: 'dshw_row' },
-            React.createElement('button', { type: 'button', className: 'dshw_btn', onClick: refreshBalance }, '\u5237\u65b0\u4f59\u989d'),
-            React.createElement('button', { type: 'button', className: 'dshw_btn dshw_btnPrimary', onClick: saveThreshold }, '\u4fdd\u5b58\u9608\u503c')),
-          React.createElement('button', {
-            type: 'button',
-            className: 'dshw_btn dshw_btnPrimary',
-            style: { textAlign: 'center' },
-            onClick: onRechargeClick
-          }, '\u2197 \u53bb\u5b98\u65b9\u5145\u503c'),
+          React.createElement('div', { className: 'dshw_actionRow' },
+            React.createElement('button', {
+              type: 'button',
+              className: 'dshw_btn dshw_btnPrimary',
+              onClick: onRechargeClick
+            }, '\u2197 \u53bb\u5b98\u65b9\u5145\u503c'),
+            React.createElement('button', { type: 'button', className: 'dshw_btn', onClick: refreshBalance }, '\u5237\u65b0\u4f59\u989d')),
+          React.createElement('div', { style: { display: 'flex', justifyContent: 'flex-end' } },
+            React.createElement('button', {
+              type: 'button',
+              className: 'dshw_textDanger',
+              onClick: function () {
+                if (window.confirm('确认清除本会话的余额与 token 数据？不可恢复。')) clearSession()
+              }
+            }, '\u6e05\u9664\u4f59\u989d\u4e0e token')),
           React.createElement('div', { className: 'dshw_divider' })) : null,
-        React.createElement('button', {
-          type: 'button',
-          className: 'dshw_btn',
-          style: { width: '100%' },
-          onClick: function () {
-            if (window.confirm('确认清除本会话的余额与 token 数据？不可恢复。')) clearSession()
-          }
-        }, '清除余额与 token'),
-        React.createElement('div', { className: 'dshw_divider' }),
         accountsSection()
       )
 


### PR DESCRIPTION
## 改动 / Changes

- 余额横排摘要卡（大数字 + 低额提醒胶囊 + 本会话花费，下行充值/赠送）/ Horizontal balance summary card
- 设置分组卡片：胶囊开关、行内滑块、提醒合并行、阈值保存贴边 / Grouped settings card
- 账户列表限高两行可滚动 + 数量提示 / Two-row scrollable account list
- 主操作并列，清除降级为安静的文本按钮 / Paired primary actions, quiet destructive
- 全部使用宿主主题变量，明暗主题适配 / Host theme variables throughout

52/52 tests pass. Verified live on dsh 0.1.0-rc.7.