### PR TITLE
feat: restyle the host settings wallet page

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -321,6 +321,15 @@ window.__ModuleLoader__.load({
       '.dshw_acctScroll::-webkit-scrollbar-thumb{background:var(--dsw-alias-border-l3,rgba(0,0,0,.25));border-radius:3px}',
       '.dshw_acctScroll .dshw_row{padding:5px 8px}',
       '.dshw_acctMore{display:flex;justify-content:flex-end;font-size:10.5px;color:var(--dsw-alias-label-quaternary,rgba(31,35,40,.45));margin-top:3px}',
+      '.dshw_acctRow{display:flex;align-items:center;gap:8px;padding:6px 8px}',
+      '.dshw_acctRow+.dshw_acctRow{border-top:1px solid var(--dsw-alias-border-l1,rgba(0,0,0,.08))}',
+      '.dshw_acctRow.current{background:var(--dsw-alias-brand-soft,rgba(74,163,255,.10))}',
+      '.dshw_acctAvatar{flex:none;width:24px;height:24px;border-radius:50%;display:inline-flex;align-items:center;justify-content:center;font-size:11.5px;font-weight:650;user-select:none}',
+      '.dshw_acctInfo{flex:1;min-width:0;display:flex;flex-direction:column;gap:1px}',
+      '.dshw_acctName{font-size:12px;font-weight:550;color:var(--dsw-alias-label-primary,inherit);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;display:flex;align-items:center;gap:5px}',
+      '.dshw_acctBadge{flex:none;font-size:9.5px;color:var(--dsw-alias-brand-primary,#4aa3ff);border:1px solid var(--dsw-alias-brand-primary,#4aa3ff);border-radius:4px;padding:0 4px;line-height:14px;opacity:.85}',
+      '.dshw_acctKey{font-family:ui-monospace,Consolas,monospace;font-size:10px;color:var(--dsw-alias-label-quaternary,rgba(31,35,40,.45));white-space:nowrap;overflow:hidden;text-overflow:ellipsis}',
+      '.dshw_acctNow{flex:none;padding:1px 7px;border-radius:999px;background:var(--dsw-alias-brand-soft,rgba(74,163,255,.14));color:var(--dsw-alias-brand-primary,#4aa3ff);font-size:10.5px;font-weight:550;line-height:16px}',
       '.dshw_actionRow{display:grid;grid-template-columns:1fr 1fr;gap:6px;margin:2px 0}',
       '.dshw_textDanger{display:inline-flex;align-items:center;gap:5px;height:22px;padding:0 4px;border:none;background:transparent;font:inherit;font-size:11px;color:var(--dsw-alias-label-quaternary,rgba(31,35,40,.45));cursor:pointer;border-radius:4px;transition:color .12s,background-color .12s}',
       '.dshw_textDanger:hover{color:var(--dsw-alias-state-error-primary,#e5534b);background:var(--dsw-alias-state-error-soft,rgba(229,83,75,.12))}',
@@ -956,44 +965,42 @@ window.__ModuleLoader__.load({
       var list = accounts && accounts.accounts ? accounts.accounts : []
       var rows = []
 
-      rows.push(React.createElement('div', { key: 'bal', className: 'dshw_row' },
-        React.createElement('span', { className: 'dshw_muted' }, '\u4f59\u989d'),
-        React.createElement('span', null, balanceText),
-        React.createElement('button', {
-          type: 'button', className: 'dshw_btn', style: { padding: '2px 8px' },
-          onClick: reloadAccounts
-        }, '\u5237\u65b0')))
+      // —— 余额卡 ——
+      var lowBalance = snapshot && snapshot.lowBalance === true
+      var sessionCost = snapshot && snapshot.session && snapshot.session.official && snapshot.session.official.cost !== null && snapshot.session.official.cost !== undefined ? fmtCurrency(snapshot.session.official.cost, 'CNY') : '--'
+      rows.push(React.createElement('div', { key: 'balcard', className: 'dshw_balanceCard' },
+        React.createElement('div', { className: 'dshw_balLine' },
+          React.createElement('span', { className: 'dshw_muted' }, '\u4f59\u989d'),
+          React.createElement('span', { className: 'dshw_balNum' }, balanceText),
+          lowBalance ? React.createElement('span', { className: 'dshw_balWarn' }, '\u4f59\u989d\u504f\u4f4e') : null,
+          React.createElement('span', { className: 'dshw_balFill' }),
+          React.createElement('span', { className: 'dshw_balSession' },
+            React.createElement('span', { className: 'dshw_muted' }, '\u672c\u4f1a\u8bdd'),
+            React.createElement('span', { className: 'dshw_balSessionNum' }, sessionCost)),
+        ),
+        React.createElement('div', { className: 'dshw_balSub' },
+          '\u5f53\u524d\u8d26\u6237\uff1a' + (activeName ? activeName + ' \u00b7 LLM \u8ba1\u8d39' : '\u8ddf\u968f\u7cfb\u7edf Key'))))
 
-      rows.push(React.createElement('div', { key: 'th', className: 'dshw_row' },
-        React.createElement('span', { className: 'dshw_muted' }, '\u4f59\u989d\u63d0\u9192\u9608\u503c (\u00a5, 0=\u5173)'),
-        React.createElement('input', {
-          className: 'dshw_input', type: 'number', min: '0', step: '0.01',
-          style: { width: '76px' },
-          value: thresholdDraft,
-          'aria-label': '\u4f59\u989d\u63d0\u9192\u9608\u503c\uff08CNY\uff09',
-          onInput: function (event) { setThresholdDraft(event.target.value) },
-          onChange: function (event) { setThresholdDraft(event.target.value) }
-        }),
-        React.createElement('button', { type: 'button', className: 'dshw_btn', onClick: saveThreshold }, '\u4fdd\u5b58'),
-        thresholdNotice ? React.createElement('span', { key: 'tn', className: 'dshw_muted' }, thresholdNotice) : null))
-
-      rows.push(React.createElement('div', { key: 'vis', className: 'dshw_row' },
+      // —— 设置卡 ——
+      var cells = []
+      cells.push(React.createElement('div', { key: 'vis', className: 'dshw_setCell' },
         React.createElement('span', { className: 'dshw_muted' }, '\u663e\u793a\u5185\u5bb9'),
-        React.createElement('label', { className: 'dshw_visibilityControl' },
+        React.createElement('span', { className: 'dshw_balFill' }),
+        React.createElement('label', { className: 'dshw_chipToggle' },
           React.createElement('input', {
-            type: 'checkbox',
-            checked: visibility.official,
+            type: 'checkbox', checked: visibility.official,
+            'aria-label': '\u663e\u793a\u5b98\u65b9\u6570\u636e',
             onChange: function (event) { persistVisibility({ official: event.target.checked, third: visibility.third }) }
-          }), '\u5b98\u65b9\u6570\u636e'),
-        React.createElement('label', { className: 'dshw_visibilityControl' },
+          }), '\u5b98\u65b9'),
+        React.createElement('label', { className: 'dshw_chipToggle' },
           React.createElement('input', {
-            type: 'checkbox',
-            checked: visibility.third,
+            type: 'checkbox', checked: visibility.third,
+            'aria-label': '\u663e\u793a\u7b2c\u4e09\u65b9 token',
             onChange: function (event) { persistVisibility({ official: visibility.official, third: event.target.checked }) }
-          }), '\u7b2c\u4e09\u65b9 token')))
-
-      rows.push(React.createElement('div', { key: 'sc', className: 'dshw_row' },
+          }), '\u7b2c\u4e09\u65b9')))
+      cells.push(React.createElement('div', { key: 'sc', className: 'dshw_setCell' },
         React.createElement('span', { className: 'dshw_muted' }, '\u82af\u7247\u6bd4\u4f8b'),
+        React.createElement('span', { className: 'dshw_balFill' }),
         React.createElement('span', { className: 'dshw_scaleControl' },
           React.createElement('input', {
             className: 'dshw_scaleInput', type: 'range', min: '75', max: String(scaleMax), step: '5',
@@ -1003,55 +1010,84 @@ window.__ModuleLoader__.load({
             onChange: function (event) { persistScale(Number.parseFloat(event.target.value) / 100) }
           }),
           React.createElement('span', { className: 'dshw_scaleValue' }, Math.round(scale * 100) + '%'))))
-
-      rows.push(React.createElement('div', { key: 'nf', className: 'dshw_row' },
+      cells.push(React.createElement('div', { key: 'nf', className: 'dshw_setCell' },
         React.createElement('span', { className: 'dshw_muted' }, '\u5b8c\u6210\u63d0\u9192'),
-        React.createElement('label', { className: 'dshw_visibilityControl' },
+        React.createElement('span', { className: 'dshw_balFill' }),
+        React.createElement('label', { className: 'dshw_check', style: { margin: 0, gap: '5px' } },
           React.createElement('input', {
-            type: 'checkbox',
-            checked: notifyEnabled,
+            type: 'checkbox', checked: notifyEnabled,
+            'aria-label': '\u5f00\u542f\u5bf9\u8bdd\u5b8c\u6210\u540e\u63d0\u9192',
             onChange: function (event) { persistNotify(event.target.checked, notifyTimeout) }
           }), '\u5f00\u542f'),
         React.createElement('select', {
-          className: 'dshw_select', style: { width: '132px' },
+          className: 'dshw_select',
           'aria-label': '\u63d0\u9192\u81ea\u52a8\u5173\u95ed\u65f6\u95f4',
-          value: notifyTimeout,
+          value: notifyTimeout, disabled: !notifyEnabled,
           onChange: function (event) { persistNotify(notifyEnabled, event.target.value) }
         },
-          React.createElement('option', { value: 'keep' }, '\u4e00\u76f4\u4fdd\u7559\uff0c\u624b\u52a8\u5173\u95ed'),
+          React.createElement('option', { value: 'keep' }, '\u4e00\u76f4\u4fdd\u7559'),
           React.createElement('option', { value: '5' }, '5 \u79d2'),
           React.createElement('option', { value: '10' }, '10 \u79d2'),
           React.createElement('option', { value: '30' }, '30 \u79d2'),
           React.createElement('option', { value: '60' }, '60 \u79d2'))))
+      cells.push(React.createElement('div', { key: 'th', className: 'dshw_setCell' },
+        React.createElement('span', { className: 'dshw_muted' }, '\u4f59\u989d\u9608\u503c'),
+        React.createElement('span', { className: 'dshw_balFill' }),
+        React.createElement('input', {
+          className: 'dshw_input', type: 'number', min: '0', step: '0.01',
+          style: { width: '76px' },
+          value: thresholdDraft,
+          'aria-label': '\u4f59\u989d\u63d0\u9192\u9608\u503c\uff08CNY\uff09',
+          onInput: function (event) { setThresholdDraft(event.target.value) },
+          onChange: function (event) { setThresholdDraft(event.target.value) }
+        }),
+        React.createElement('button', {
+          type: 'button', className: 'dshw_btn',
+          style: { height: '24px', padding: '0 12px', fontSize: '11.5px' },
+          onClick: saveThreshold
+        }, '\u4fdd\u5b58')))
+      if (thresholdNotice) cells.push(React.createElement('div', { key: 'tn', className: 'dshw_setCell', style: { minHeight: '26px' } },
+        React.createElement('span', { className: 'dshw_muted', style: { marginLeft: 'auto' } }, thresholdNotice)))
+      rows.push(React.createElement('div', { key: 'setcard', className: 'dshw_setCard' }, cells))
 
-      rows.push(React.createElement('div', { key: 'acc-t', className: 'dshw_title', style: { marginTop: '6px' } }, '\u8d26\u6237\u7ba1\u7406'))
-      rows.push(React.createElement('div', { key: 'acc-cur', className: 'dshw_row' },
-        React.createElement('span', { className: 'dshw_muted' }, '\u5f53\u524d\u8d26\u6237'),
-        React.createElement('span', null, activeName ? activeName + ' \u00b7 LLM \u8ba1\u8d39' : '\u8ddf\u968f\u7cfb\u7edf Key')))
+      // —— 账户管理 ——
+      rows.push(React.createElement('div', { key: 'acc-t', className: 'dshw_title', style: { marginTop: '8px' } }, '\u8d26\u6237\u7ba1\u7406'))
       if (accountsError) {
         rows.push(React.createElement('div', { key: 'acc-e', className: 'dshw_muted' }, accountsError))
       } else if (list.length === 0) {
         rows.push(React.createElement('div', { key: 'acc-none', className: 'dshw_muted' }, '\u6682\u65e0\u8d26\u6237\uff0c\u6dfb\u52a0\u540e\u5c06\u81ea\u52a8\u6210\u4e3a\u5f53\u524d\u8d26\u6237'))
+      } else {
+        var AVATAR_HUES = [212, 262, 152, 22, 338, 180]
+        var acctRows = list.map(function (acc, i) {
+          var hue = AVATAR_HUES[i % AVATAR_HUES.length]
+          return React.createElement('div', { key: acc.id, className: acc.active ? 'dshw_acctRow current' : 'dshw_acctRow' },
+            React.createElement('span', {
+              className: 'dshw_acctAvatar',
+              style: { background: 'oklch(0.72 0.14 ' + hue + ' / 0.22)', color: 'oklch(0.5 0.16 ' + hue + ')' }
+            }, acc.name.trim().charAt(0).toUpperCase()),
+            React.createElement('span', { className: 'dshw_acctInfo' },
+              React.createElement('span', { className: 'dshw_acctName' },
+                acc.name,
+                acc.active ? React.createElement('span', { className: 'dshw_acctBadge' }, 'LLM \u8ba1\u8d39\u4e2d') : null),
+              React.createElement('span', { className: 'dshw_acctKey' }, acc.maskedKey)),
+            acc.active
+              ? React.createElement('span', { key: 'a', className: 'dshw_acctNow' }, '\u5f53\u524d')
+              : React.createElement('button', {
+                  key: 's', type: 'button', className: 'dshw_btn',
+                  style: { height: '22px', padding: '0 10px', fontSize: '11px' },
+                  disabled: switchingId !== null,
+                  onClick: function () { activateAccount(acc.id, acc.name) }
+                }, switchingId === acc.id ? '\u2026' : '\u5207\u6362'),
+            React.createElement('button', {
+              key: 'r', type: 'button', className: 'dshw_btn',
+              style: { height: '22px', padding: '0 7px', fontSize: '11px' },
+              title: '\u5220\u9664\u8d26\u6237',
+              onClick: function () { removeAccount(acc.id, acc.name) }
+            }, '\u00d7'))
+        })
+        rows.push(React.createElement('div', { key: 'acc-scroll', className: 'dshw_acctScroll' }, acctRows))
+        if (list.length > 2) rows.push(React.createElement('div', { key: 'acc-more', className: 'dshw_acctMore' }, '\u5171 ' + list.length + ' \u4e2a\u8d26\u6237\uff0c\u6ed1\u52a8\u67e5\u770b\u66f4\u591a'))
       }
-          list.forEach(function (acc) {
-        rows.push(React.createElement('div', { key: 'acc-' + acc.id, className: 'dshw_row' },
-          React.createElement('span', {
-            className: 'dshw_title',
-            style: { flex: '1 1 auto', minWidth: '0', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }
-          }, acc.name),
-          React.createElement('span', { className: 'dshw_muted' }, acc.maskedKey),
-          acc.active
-            ? React.createElement('span', { key: 'a', className: 'dshw_muted' }, '\u5f53\u524d')
-            : React.createElement('button', {
-                key: 's', type: 'button', className: 'dshw_btn', style: { padding: '2px 8px' },
-                disabled: switchingId !== null,
-                onClick: function () { activateAccount(acc.id, acc.name) }
-              }, switchingId === acc.id ? '\u2026' : '\u5207\u6362'),
-          React.createElement('button', {
-            key: 'r', type: 'button', className: 'dshw_btn', style: { padding: '2px 6px' },
-            onClick: function () { removeAccount(acc.id, acc.name) }
-          }, '\u00d7')))
-      })
       rows.push(React.createElement('div', { key: 'acc-add', className: 'dshw_row', style: { gap: '4px' } },
         React.createElement('input', {
           className: 'dshw_input', style: { width: '84px' },
@@ -1067,22 +1103,27 @@ window.__ModuleLoader__.load({
           onInput: function (event) { setKeyDraft(event.target.value) },
           onChange: function (event) { setKeyDraft(event.target.value) }
         }),
-        React.createElement('button', { type: 'button', className: 'dshw_btn', onClick: addAccount }, '\u6dfb\u52a0')))
+        React.createElement('button', {
+          type: 'button', className: 'dshw_btn dshw_btnPrimary',
+          onClick: addAccount
+        }, '添加')))
       if (accountNotice) {
         rows.push(React.createElement('div', { key: 'acc-n', className: 'dshw_muted' }, accountNotice))
       }
 
-      rows.push(React.createElement('div', { key: 'acts', className: 'dshw_row', style: { marginTop: '6px' } },
+      // —— 操作行 ——
+      rows.push(React.createElement('div', { key: 'acts', className: 'dshw_actionRow', style: { marginTop: '8px' } },
+        React.createElement('button', {
+          type: 'button', className: 'dshw_btn dshw_btnPrimary',
+          onClick: function () { if (close) close(); window.open('https://platform.deepseek.com/top_up', '_blank', 'noopener') }
+        }, '\u2197 \u53bb\u5b98\u65b9\u5145\u503c'),
         React.createElement('button', {
           type: 'button', className: 'dshw_btn',
           onClick: function () {
             fetch('/api/wallet/refresh', { method: 'POST' }).then(reloadAccounts).catch(function () { /* ignore */ })
           }
-        }, '\u5237\u65b0\u4f59\u989d'),
-        React.createElement('button', {
-          type: 'button', className: 'dshw_btn',
-          onClick: function () { if (close) close(); window.open('https://platform.deepseek.com/top_up', '_blank', 'noopener') }
-        }, '\u2197 \u53bb\u5b98\u65b9\u5145\u503c')))
+        }, '\u5237\u65b0\u4f59\u989d')))
+
 
       return React.createElement('div', { className: 'dshw_settingsSection', style: { display: 'flex', flexDirection: 'column', gap: '6px', fontSize: '12px', color: 'var(--dsw-alias-label-primary,#1f2328)' } }, rows)
     }
@@ -2534,6 +2575,7 @@ window.__ModuleLoader__.load({
       normalizeNotifyConfig: normalizeNotifyConfig,
       normalizeChipLayout: normalizeChipLayout,
       normalizeChipScale: normalizeChipScale,
+      WalletSettingsSection: WalletSettingsSection,
       settleDotPosition: settleDotPosition
     }
     return module.exports

--- a/test/wallet.test.mjs
+++ b/test/wallet.test.mjs
@@ -1468,3 +1468,18 @@ test('plugin registers a host settings-panel section below the visual tools', ()
   const chip = findElement(tree, (element) => element.props && element.props['aria-label'] === 'DeepSeek 钱包')
   assert.ok(chip, 'the composer chip must keep rendering')
 })
+
+test('host settings section renders the restyled card without crashing', () => {
+  const renderer = createHookRenderer()
+  const { exports, window } = loadClientBundle(renderer.React)
+  // fetch 在测试环境不可达: 组件必须走错误分支也不崩
+  const Section = exports.__testing.WalletSettingsSection
+  assert.equal(typeof Section, 'function', 'WalletSettingsSection must be exported for render coverage')
+  let tree = renderer.render(Section, { close: function () {} })
+  // 异步 fetch 完成后再渲染一帧(错误/空数据分支)
+  tree = renderer.render(Section, { close: function () {} })
+  const balanceCard = findElement(tree, (element) => element.props && String(element.props.className || '').includes('dshw_balanceCard'))
+  const setCard = findElement(tree, (element) => element.props && String(element.props.className || '').includes('dshw_setCard'))
+  assert.ok(balanceCard, 'the settings section must render the balance card')
+  assert.ok(setCard, 'the settings section must render the grouped settings card')
+})


### PR DESCRIPTION
## 改动 / Changes

- 设置页「钱包」与明细面板统一新视觉：余额摘要卡、分组设置卡（胶囊开关/行内滑块/阈值保存贴边）、账户行带彩色首字头像与徽章、限高两行滚动 / Unified restyle with the detail panel
- 新增设置页渲染测试，杜绝未验证渲染就发布 / Adds a render test for the section

53/53 tests pass.