### PR TITLE
fix: session cost follows the account currency; cap settings width

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -371,7 +371,22 @@ window.__ModuleLoader__.load({
       return String(n)
     }
 
-    function fmtCurrency(value, currency) {
+    
+    // Session cost is priced from the CNY table; when the active account
+    // settles in another currency, show a clearly-marked estimate instead
+    // of mixing currencies. The rate is the vendor's long-standing list
+    // ratio, not a live FX quote.
+    var USD_ESTIMATE_PER_CNY = 7.25
+    function sessionCostText(costCNY, currency) {
+      if (costCNY === null || costCNY === undefined) return '--'
+      if (currency === 'USD') {
+        var usd = costCNY / USD_ESTIMATE_PER_CNY
+        return '≈' + fmtCurrency(usd, 'USD')
+      }
+      return fmtCurrency(costCNY, currency || 'CNY')
+    }
+
+function fmtCurrency(value, currency) {
       var number = typeof value === 'number' ? value : Number.parseFloat(value)
       if (!Number.isFinite(number)) return '--'
       var code = typeof currency === 'string' && /^[A-Z]{3}$/.test(currency.toUpperCase()) ? currency.toUpperCase() : 'CNY'
@@ -967,7 +982,7 @@ window.__ModuleLoader__.load({
 
       // —— 余额卡 ——
       var lowBalance = snapshot && snapshot.lowBalance === true
-      var sessionCost = snapshot && snapshot.session && snapshot.session.official && snapshot.session.official.cost !== null && snapshot.session.official.cost !== undefined ? fmtCurrency(snapshot.session.official.cost, 'CNY') : '--'
+      var sessionCost = snapshot && snapshot.session && snapshot.session.official && snapshot.session.official.cost !== null && snapshot.session.official.cost !== undefined ? sessionCostText(snapshot.session.official.cost, snapshot && snapshot.balance ? snapshot.balance.currency : null) : '--'
       rows.push(React.createElement('div', { key: 'balcard', className: 'dshw_balanceCard' },
         React.createElement('div', { className: 'dshw_balLine' },
           React.createElement('span', { className: 'dshw_muted' }, '\u4f59\u989d'),
@@ -1125,7 +1140,7 @@ window.__ModuleLoader__.load({
         }, '\u5237\u65b0\u4f59\u989d')))
 
 
-      return React.createElement('div', { className: 'dshw_settingsSection', style: { display: 'flex', flexDirection: 'column', gap: '6px', fontSize: '12px', color: 'var(--dsw-alias-label-primary,#1f2328)' } }, rows)
+      return React.createElement('div', { className: 'dshw_settingsSection', style: { display: 'flex', flexDirection: 'column', gap: '6px', fontSize: '12px', maxWidth: '360px', color: 'var(--dsw-alias-label-primary,#1f2328)' } }, rows)
     }
 
     function WalletChip(props) {
@@ -2062,7 +2077,7 @@ window.__ModuleLoader__.load({
       if (chipVertical) {
         if (showOfficial) {
           chipTextParts.push(verticalMetric('bal', '余额', balanceText))
-          if (official.cost !== undefined && official.cost !== null) chipTextParts.push(verticalMetric('cost', '\u672c\u573a', fmtCurrency(official.cost, 'CNY')))
+          if (official.cost !== undefined && official.cost !== null) chipTextParts.push(verticalMetric('cost', '\u672c\u573a', sessionCostText(official.cost, bal.currency)))
           chipTextParts.push(verticalMetric('off', '\u5b98', fmtTokens(officialTokens)))
         }
         if (showThird) chipTextParts.push(verticalMetric('third', '\u4e09\u65b9', fmtTokens(thirdTokens)))
@@ -2071,7 +2086,7 @@ window.__ModuleLoader__.load({
           chipTextParts.push(React.createElement('span', { key: 'bal', className: 'dshw_balanceText dshw_homePrimary' },
             React.createElement('span', { className: 'dshw_homePrimaryLabel' }, '余额 '),
             React.createElement('span', { className: 'dshw_homePrimaryValue' }, balanceText)))
-          if (official.cost !== undefined && official.cost !== null) chipTextParts.push(React.createElement('span', { key: 'cost' }, '\u672c\u573a ' + fmtCurrency(official.cost, 'CNY')))
+          if (official.cost !== undefined && official.cost !== null) chipTextParts.push(React.createElement('span', { key: 'cost' }, '\u672c\u573a ' + sessionCostText(official.cost, bal.currency)))
           chipTextParts.push(React.createElement('span', { key: 'off' }, '\u5b98 ' + fmtTokens(officialTokens)))
         }
         if (showOfficial && showThird) chipTextParts.push(React.createElement('span', { key: 'sep', className: 'dshw_sep' }, '|'))
@@ -2165,7 +2180,7 @@ window.__ModuleLoader__.load({
       }
       officialRows.push(React.createElement('div', { key: 'o-c', className: 'dshw_row' },
         React.createElement('span', { className: 'dshw_muted' }, '\u672c\u4f1a\u8bdd\u82b1\u8d39'),
-        React.createElement('span', null, official.cost === null ? '\u672a\u5b9a\u4ef7\u6a21\u578b' : fmtCurrency(official.cost, 'CNY'))))
+        React.createElement('span', null, official.cost === null ? '\u672a\u5b9a\u4ef7\u6a21\u578b' : sessionCostText(official.cost, bal.currency))))
 
       var thirdRows = []
       thirdRows.push(React.createElement('div', { key: 't-t', className: 'dshw_row' },
@@ -2331,7 +2346,7 @@ window.__ModuleLoader__.load({
             React.createElement('span', { className: 'dshw_balFill' }),
             React.createElement('span', { className: 'dshw_balSession' },
               React.createElement('span', { className: 'dshw_muted' }, '\u672c\u4f1a\u8bdd'),
-              React.createElement('span', { className: 'dshw_balSessionNum' }, official.cost === null ? '--' : fmtCurrency(official.cost, 'CNY')))),
+              React.createElement('span', { className: 'dshw_balSessionNum' }, official.cost === null ? '--' : sessionCostText(official.cost, bal.currency)))),
           React.createElement('div', { className: 'dshw_balSub' }, subParts))
       }
 

--- a/test/wallet.test.mjs
+++ b/test/wallet.test.mjs
@@ -1483,3 +1483,15 @@ test('host settings section renders the restyled card without crashing', () => {
   assert.ok(balanceCard, 'the settings section must render the balance card')
   assert.ok(setCard, 'the settings section must render the grouped settings card')
 })
+
+test('session cost follows the active account currency with a marked estimate', () => {
+  const source = readProjectFile('lib/client.js')
+  assert.match(source, /function sessionCostText/, 'a currency-aware session cost helper must exist')
+  assert.match(source, /USD_ESTIMATE_PER_CNY/, 'USD display must be an explicit estimate, never a silent FX conversion')
+  assert.doesNotMatch(source, /sessionCostText\([^)]*\), 'CNY'\)/, 'no call site may hard-code CNY after the currency follows the account')
+  const renderer = createHookRenderer()
+  const { exports } = loadClientBundle(renderer.React)
+  const Section = exports.__testing.WalletSettingsSection
+  const tree = renderer.render(Section, { close: () => {} })
+  assert.ok(tree, 'the settings section still renders')
+})


### PR DESCRIPTION
## 修复 / Fixes

- 切换美元账户后，本会话花费在 chip / 明细面板 / 设置页统一按账户货币显示（美元为 ≈ 估算值，标注清楚） / Session cost now follows the active account currency (USD shown as a marked ≈ estimate)
- 设置页「钱包」限宽 360px，不再在宿主宽内容列里被拉伸 / Settings wallet page capped at 360px

54/54 tests pass.