### PR TITLE
fix: move session cost to the balance sub-line

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -987,13 +987,10 @@ function fmtCurrency(value, currency) {
         React.createElement('div', { className: 'dshw_balLine' },
           React.createElement('span', { className: 'dshw_muted' }, '\u4f59\u989d'),
           React.createElement('span', { className: 'dshw_balNum' }, balanceText),
-          lowBalance ? React.createElement('span', { className: 'dshw_balWarn' }, '\u4f59\u989d\u504f\u4f4e') : null,
-          React.createElement('span', { className: 'dshw_balFill' }),
-          React.createElement('span', { className: 'dshw_balSession' },
-            React.createElement('span', { className: 'dshw_muted' }, '\u672c\u4f1a\u8bdd'),
-            React.createElement('span', { className: 'dshw_balSessionNum' }, sessionCost)),
-        ),
+          lowBalance ? React.createElement('span', { className: 'dshw_balWarn' }, '\u4f59\u989d\u504f\u4f4e') : null),
         React.createElement('div', { className: 'dshw_balSub' },
+          '\u672c\u4f1a\u8bdd ' + sessionCost,
+          React.createElement('span', { className: 'dshw_balDot' }, '\u00b7'),
           '\u5f53\u524d\u8d26\u6237\uff1a' + (activeName ? activeName + ' \u00b7 LLM \u8ba1\u8d39' : '\u8ddf\u968f\u7cfb\u7edf Key'))))
 
       // —— 设置卡 ——
@@ -2342,12 +2339,11 @@ function fmtCurrency(value, currency) {
           React.createElement('div', { className: 'dshw_balLine' },
             React.createElement('span', { className: 'dshw_muted' }, '\u4f59\u989d'),
             React.createElement('span', { className: 'dshw_balNum' }, fmtCurrency(first.total_balance, first.currency)),
-            low ? React.createElement('span', { className: 'dshw_balWarn', title: '\u4f4e\u4e8e\u63d0\u9192\u9608\u503c \u00a5' + (snapshot.threshold !== undefined ? snapshot.threshold : '') }, '\u4f59\u989d\u504f\u4f4e') : null,
-            React.createElement('span', { className: 'dshw_balFill' }),
-            React.createElement('span', { className: 'dshw_balSession' },
-              React.createElement('span', { className: 'dshw_muted' }, '\u672c\u4f1a\u8bdd'),
-              React.createElement('span', { className: 'dshw_balSessionNum' }, official.cost === null ? '--' : sessionCostText(official.cost, bal.currency)))),
-          React.createElement('div', { className: 'dshw_balSub' }, subParts))
+            low ? React.createElement('span', { className: 'dshw_balWarn', title: '\u4f4e\u4e8e\u63d0\u9192\u9608\u503c \u00a5' + (snapshot.threshold !== undefined ? snapshot.threshold : '') }, '\u4f59\u989d\u504f\u4f4e') : null),
+          React.createElement('div', { className: 'dshw_balSub' },
+            '\u672c\u4f1a\u8bdd ' + (official.cost === null ? '--' : sessionCostText(official.cost, bal.currency)),
+            React.createElement('span', { className: 'dshw_balDot' }, '\u00b7'),
+            subParts))
       }
 
       // All controls in one bordered card with compact rows; the threshold


### PR DESCRIPTION
美元金额更长导致余额主行溢出错位，本会话花费移到副行，主行任何货币都不会溢出。/ Session cost moved to the sub-line so the hero row never overflows. 54/54 tests pass.