### PR TITLE
fix: two-column grid for the wallet settings page

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -330,6 +330,10 @@ window.__ModuleLoader__.load({
       '.dshw_acctBadge{flex:none;font-size:9.5px;color:var(--dsw-alias-brand-primary,#4aa3ff);border:1px solid var(--dsw-alias-brand-primary,#4aa3ff);border-radius:4px;padding:0 4px;line-height:14px;opacity:.85}',
       '.dshw_acctKey{font-family:ui-monospace,Consolas,monospace;font-size:10px;color:var(--dsw-alias-label-quaternary,rgba(31,35,40,.45));white-space:nowrap;overflow:hidden;text-overflow:ellipsis}',
       '.dshw_acctNow{flex:none;padding:1px 7px;border-radius:999px;background:var(--dsw-alias-brand-soft,rgba(74,163,255,.14));color:var(--dsw-alias-brand-primary,#4aa3ff);font-size:10.5px;font-weight:550;line-height:16px}',
+      '.dshw_settingsSection .dshw_setCard{display:grid;grid-template-columns:1fr 1fr;gap:1px;background:var(--dsw-alias-border-l1,rgba(0,0,0,.08))}',
+      '.dshw_settingsSection .dshw_setCell{background:var(--dsw-alias-bg-elevated,transparent);border-top:none!important;padding:8px 10px}',
+      '.dshw_settingsSection .dshw_setCell:hover{background:var(--dsw-alias-bg-l1,rgba(127,127,127,.06))}',
+      '.dshw_settingsSection .dshw_setCell.wide{grid-column:1/-1}',
       '.dshw_actionRow{display:grid;grid-template-columns:1fr 1fr;gap:6px;margin:2px 0}',
       '.dshw_textDanger{display:inline-flex;align-items:center;gap:5px;height:22px;padding:0 4px;border:none;background:transparent;font:inherit;font-size:11px;color:var(--dsw-alias-label-quaternary,rgba(31,35,40,.45));cursor:pointer;border-radius:4px;transition:color .12s,background-color .12s}',
       '.dshw_textDanger:hover{color:var(--dsw-alias-state-error-primary,#e5534b);background:var(--dsw-alias-state-error-soft,rgba(229,83,75,.12))}',
@@ -987,10 +991,12 @@ function fmtCurrency(value, currency) {
         React.createElement('div', { className: 'dshw_balLine' },
           React.createElement('span', { className: 'dshw_muted' }, '\u4f59\u989d'),
           React.createElement('span', { className: 'dshw_balNum' }, balanceText),
-          lowBalance ? React.createElement('span', { className: 'dshw_balWarn' }, '\u4f59\u989d\u504f\u4f4e') : null),
+          lowBalance ? React.createElement('span', { className: 'dshw_balWarn' }, '\u4f59\u989d\u504f\u4f4e') : null,
+          React.createElement('span', { className: 'dshw_balFill' }),
+          React.createElement('span', { className: 'dshw_balSession' },
+            React.createElement('span', { className: 'dshw_muted' }, '\u672c\u4f1a\u8bdd'),
+            React.createElement('span', { className: 'dshw_balSessionNum' }, sessionCost))),
         React.createElement('div', { className: 'dshw_balSub' },
-          '\u672c\u4f1a\u8bdd ' + sessionCost,
-          React.createElement('span', { className: 'dshw_balDot' }, '\u00b7'),
           '\u5f53\u524d\u8d26\u6237\uff1a' + (activeName ? activeName + ' \u00b7 LLM \u8ba1\u8d39' : '\u8ddf\u968f\u7cfb\u7edf Key'))))
 
       // —— 设置卡 ——
@@ -1058,7 +1064,7 @@ function fmtCurrency(value, currency) {
           style: { height: '24px', padding: '0 12px', fontSize: '11.5px' },
           onClick: saveThreshold
         }, '\u4fdd\u5b58')))
-      if (thresholdNotice) cells.push(React.createElement('div', { key: 'tn', className: 'dshw_setCell', style: { minHeight: '26px' } },
+      if (thresholdNotice) cells.push(React.createElement('div', { key: 'tn', className: 'dshw_setCell wide', style: { minHeight: '26px' } },
         React.createElement('span', { className: 'dshw_muted', style: { marginLeft: 'auto' } }, thresholdNotice)))
       rows.push(React.createElement('div', { key: 'setcard', className: 'dshw_setCard' }, cells))
 
@@ -1137,7 +1143,7 @@ function fmtCurrency(value, currency) {
         }, '\u5237\u65b0\u4f59\u989d')))
 
 
-      return React.createElement('div', { className: 'dshw_settingsSection', style: { display: 'flex', flexDirection: 'column', gap: '6px', fontSize: '12px', maxWidth: '360px', color: 'var(--dsw-alias-label-primary,#1f2328)' } }, rows)
+      return React.createElement('div', { className: 'dshw_settingsSection', style: { display: 'flex', flexDirection: 'column', gap: '6px', fontSize: '12px', color: 'var(--dsw-alias-label-primary,#1f2328)' } }, rows)
     }
 
     function WalletChip(props) {


### PR DESCRIPTION
设置页钱包页去掉 360px 限宽，控制项两列网格铺满内容列，余额行恢复横排；明细面板（276px）保持单列。/ Drops the width cap; settings controls in a 2-column grid; balance hero row restored. 54/54 tests pass.