### PR TITLE
chore: 本约 label replaces the ≈ prefix

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -385,9 +385,14 @@ window.__ModuleLoader__.load({
       if (costCNY === null || costCNY === undefined) return '--'
       if (currency === 'USD') {
         var usd = costCNY / USD_ESTIMATE_PER_CNY
-        return '≈' + fmtCurrency(usd, 'USD')
+        return fmtCurrency(usd, 'USD')
       }
       return fmtCurrency(costCNY, currency || 'CNY')
+    }
+    // 本约 = "本次为估算值"：美元账户的花费由 CNY 价折算，标签本身承担
+    // 约算含义，数字前不再加 ≈ 符号；CNY 账户是精确值，用"本场"。
+    function sessionCostLabel(currency) {
+      return currency === 'USD' ? '本约' : '本场'
     }
 
 function fmtCurrency(value, currency) {
@@ -994,7 +999,7 @@ function fmtCurrency(value, currency) {
           lowBalance ? React.createElement('span', { className: 'dshw_balWarn' }, '\u4f59\u989d\u504f\u4f4e') : null,
           React.createElement('span', { className: 'dshw_balFill' }),
           React.createElement('span', { className: 'dshw_balSession' },
-            React.createElement('span', { className: 'dshw_muted' }, '\u672c\u4f1a\u8bdd'),
+            React.createElement('span', { className: 'dshw_muted' }, sessionCostLabel(snapshot && snapshot.balance ? snapshot.balance.currency : null)),
             React.createElement('span', { className: 'dshw_balSessionNum' }, sessionCost))),
         React.createElement('div', { className: 'dshw_balSub' },
           '\u5f53\u524d\u8d26\u6237\uff1a' + (activeName ? activeName + ' \u00b7 LLM \u8ba1\u8d39' : '\u8ddf\u968f\u7cfb\u7edf Key'))))
@@ -2080,7 +2085,7 @@ function fmtCurrency(value, currency) {
       if (chipVertical) {
         if (showOfficial) {
           chipTextParts.push(verticalMetric('bal', '余额', balanceText))
-          if (official.cost !== undefined && official.cost !== null) chipTextParts.push(verticalMetric('cost', '\u672c\u573a', sessionCostText(official.cost, bal.currency)))
+          if (official.cost !== undefined && official.cost !== null) chipTextParts.push(verticalMetric('cost', sessionCostLabel(bal.currency), sessionCostText(official.cost, bal.currency)))
           chipTextParts.push(verticalMetric('off', '\u5b98', fmtTokens(officialTokens)))
         }
         if (showThird) chipTextParts.push(verticalMetric('third', '\u4e09\u65b9', fmtTokens(thirdTokens)))
@@ -2089,7 +2094,7 @@ function fmtCurrency(value, currency) {
           chipTextParts.push(React.createElement('span', { key: 'bal', className: 'dshw_balanceText dshw_homePrimary' },
             React.createElement('span', { className: 'dshw_homePrimaryLabel' }, '余额 '),
             React.createElement('span', { className: 'dshw_homePrimaryValue' }, balanceText)))
-          if (official.cost !== undefined && official.cost !== null) chipTextParts.push(React.createElement('span', { key: 'cost' }, '\u672c\u573a ' + sessionCostText(official.cost, bal.currency)))
+          if (official.cost !== undefined && official.cost !== null) chipTextParts.push(React.createElement('span', { key: 'cost' }, sessionCostLabel(bal.currency) + ' ' + sessionCostText(official.cost, bal.currency)))
           chipTextParts.push(React.createElement('span', { key: 'off' }, '\u5b98 ' + fmtTokens(officialTokens)))
         }
         if (showOfficial && showThird) chipTextParts.push(React.createElement('span', { key: 'sep', className: 'dshw_sep' }, '|'))
@@ -2347,7 +2352,7 @@ function fmtCurrency(value, currency) {
             React.createElement('span', { className: 'dshw_balNum' }, fmtCurrency(first.total_balance, first.currency)),
             low ? React.createElement('span', { className: 'dshw_balWarn', title: '\u4f4e\u4e8e\u63d0\u9192\u9608\u503c \u00a5' + (snapshot.threshold !== undefined ? snapshot.threshold : '') }, '\u4f59\u989d\u504f\u4f4e') : null),
           React.createElement('div', { className: 'dshw_balSub' },
-            '\u672c\u4f1a\u8bdd ' + (official.cost === null ? '--' : sessionCostText(official.cost, bal.currency)),
+            sessionCostLabel(bal.currency) + ' ' + (official.cost === null ? '--' : sessionCostText(official.cost, bal.currency)),
             React.createElement('span', { className: 'dshw_balDot' }, '\u00b7'),
             subParts))
       }


### PR DESCRIPTION
\u7ea6\u7b97\u6807\u8bb0\u4ece\u6570\u5b57\u79fb\u5165\u6587\u5b57\u6807\u7b7e\uff1a\u7f8e\u5143\u8d26\u6237\u663e\u793a\u300c\u672c\u7ea6 $x\u300d\uff0c\u4eba\u6c11\u5e01\u8d26\u6237\u663e\u793a\u7cbe\u786e\u7684\u300c\u672c\u573a \u00a5x\u300d\u3002/ Estimate marker moved from the number into the label. 54/54 tests pass.