### PR TITLE
fix: hide sub-cent session spend on the chip

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -2082,10 +2082,15 @@ function fmtCurrency(value, currency) {
           React.createElement('span', { className: 'dshw_metricLabel' }, label),
           React.createElement('span', { className: 'dshw_metricValue' }, value))
       }
+      // A session spend below the display precision renders as $0.00 —
+      // pure noise on the space-constrained chip, so hide it there. The
+      // panels keep showing it.
+      var chipCostVisible = official.cost !== undefined && official.cost !== null
+        && (bal.currency === 'USD' ? official.cost / USD_ESTIMATE_PER_CNY : official.cost) >= 0.005
       if (chipVertical) {
         if (showOfficial) {
           chipTextParts.push(verticalMetric('bal', '余额', balanceText))
-          if (official.cost !== undefined && official.cost !== null) chipTextParts.push(verticalMetric('cost', sessionCostLabel(bal.currency), sessionCostText(official.cost, bal.currency)))
+          if (chipCostVisible) chipTextParts.push(verticalMetric('cost', sessionCostLabel(bal.currency), sessionCostText(official.cost, bal.currency)))
           chipTextParts.push(verticalMetric('off', '\u5b98', fmtTokens(officialTokens)))
         }
         if (showThird) chipTextParts.push(verticalMetric('third', '\u4e09\u65b9', fmtTokens(thirdTokens)))
@@ -2094,7 +2099,7 @@ function fmtCurrency(value, currency) {
           chipTextParts.push(React.createElement('span', { key: 'bal', className: 'dshw_balanceText dshw_homePrimary' },
             React.createElement('span', { className: 'dshw_homePrimaryLabel' }, '余额 '),
             React.createElement('span', { className: 'dshw_homePrimaryValue' }, balanceText)))
-          if (official.cost !== undefined && official.cost !== null) chipTextParts.push(React.createElement('span', { key: 'cost' }, sessionCostLabel(bal.currency) + ' ' + sessionCostText(official.cost, bal.currency)))
+          if (chipCostVisible) chipTextParts.push(React.createElement('span', { key: 'cost' }, sessionCostLabel(bal.currency) + ' ' + sessionCostText(official.cost, bal.currency)))
           chipTextParts.push(React.createElement('span', { key: 'off' }, '\u5b98 ' + fmtTokens(officialTokens)))
         }
         if (showOfficial && showThird) chipTextParts.push(React.createElement('span', { key: 'sep', className: 'dshw_sep' }, '|'))


### PR DESCRIPTION
chip 上 $0.00/\u00a50.00 级别的会话花费是纯噪声还占宽度（叠加官方 token 数增长后 120% 放不下），现在低于最小显示精度就隐藏该段，面板照常显示。/ Sub-cent session spend is hidden on the chip (kept in panels), restoring the full layout at 120%. 54/54 tests pass.