### PR TITLE
feat: wrapper provider routes can bill officially (Fixes #21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project are documented in this file.
 - 新增多账户管理与热切换：面板内“账户管理”可添加多个账户（名称 + API Key），切换后无需重启，下一次 LLM 调用即按新账户计费；key 界面掩码显示，余额查询跟随当前账户（contributed in PR #4 by mxchen-xyz）。 / Added multi-account management with hot switching: manage accounts in the panel, and the very next LLM call is billed with the newly activated key — no restart needed; keys stay masked in the UI and balance follows the active account.
 - 面板视觉重做：余额横排摘要卡、设置合并为分组卡片（胶囊开关、行内滑块、阈值保存贴边）、账户列表限高两行滚动、主操作并列与安静的清除入口。 / Restyled the panel: horizontal balance summary card, grouped settings card (chip toggles, inline slider, threshold save inline), two-row scrollable account list, and paired primary actions with a quiet destructive entry.
 - 宿主设置面板（视觉工具下方）新增「钱包」设置页：余额、阈值、显示内容、芯片比例、完成提醒与账户管理，与标签面板实时同步。 / Added a 钱包 (Wallet) page to the host settings panel below Visual tools: balance, threshold, visibility, chip scale, completion reminders, and account management, kept in sync with the chip panel.
+- 设置页钱包页两列网格布局铺满宿主内容列，余额行横排。 / The settings wallet page lays controls out in a two-column grid that fills the host settings column.
+- 会话花费跟随当前账户货币：美元账户显示「本约 $x」（按 CNY 价折算的估算值，标签承担约算含义），人民币账户显示精确的「本场 ¥x」。 / Session cost follows the active account currency: USD accounts show 本约 $x (a labeled estimate converted from the CNY table), CNY accounts show the exact 本场 figure.
+- 芯片上低于显示精度的会话花费（如 $0.00）直接隐藏，面板照常显示，高缩放下更容易保持完整布局。 / Sub-cent session spend is hidden on the chip (kept in panels) so the full layout survives high scale factors.
+- 输入框位置缩放上限进一步收紧为 105%（悬浮/侧边仍 125%）。
+- 包装官方的路由（如 dsh-vision-proxy 的 deepseek-vision）可勾选计入官方计费桶：设置页新增「Provider 分桶」，自动列出出现过的 provider，勾选即按官方价格计入本场花费（Fixes #21, reported by @wenjie0112）。 / Wrapper provider routes (e.g. deepseek-vision from dsh-vision-proxy) can be checked into the official billing bucket: the settings page gains a Provider section listing observed providers; checked ones bill officially. / The composer-docked scale cap tightens to 105% (floating and side docks keep 125%).
 
 ## 0.1.5 - 2026-08-18
 

--- a/index.js
+++ b/index.js
@@ -151,6 +151,27 @@ function migratedOfficialBucket(value, atMs) {
   return { models, cost, priced }
 }
 
+// Provider-route aliasing: wrapper plugins (e.g. vision proxies) sit in front
+// of the official API under their own provider id, so the bucket check must be
+// a configured set rather than one hard-coded name.
+export function normalizeProviderList(value) {
+  if (!Array.isArray(value)) return []
+  const seen = new Set()
+  for (const item of value) {
+    if (typeof item !== 'string' || item === '' || item.length > 100) continue
+    if (item === '__proto__' || item === 'prototype' || item === 'constructor') continue
+    if (item === OFFICIAL_PROVIDER) continue
+    seen.add(item)
+    if (seen.size >= 20) break
+  }
+  return [...seen]
+}
+
+export function isOfficialProvider(provider, extraProviders) {
+  if (provider === OFFICIAL_PROVIDER) return true
+  return Array.isArray(extraProviders) && extraProviders.includes(provider)
+}
+
 export function normalizeStoreData(value, atMs = Date.now()) {
   const source = value !== null && typeof value === 'object' && !Array.isArray(value) ? value : {}
   const rawSessions = source.sessions !== null && typeof source.sessions === 'object' && !Array.isArray(source.sessions)
@@ -165,7 +186,13 @@ export function normalizeStoreData(value, atMs = Date.now()) {
       third: { models: normalizeModels(rawSession.third && rawSession.third.models) },
     }
   }
-  const normalized = { version: STORE_VERSION, threshold: normalizeThreshold(source.threshold), sessions }
+  const normalized = {
+    version: STORE_VERSION,
+    threshold: normalizeThreshold(source.threshold),
+    sessions,
+    officialProviders: normalizeProviderList(source.officialProviders),
+    knownProviders: normalizeProviderList(source.knownProviders),
+  }
   return { store: normalized, migrated: JSON.stringify(source) !== JSON.stringify(normalized) }
 }
 
@@ -554,6 +581,14 @@ function snapshotView(sessionId, threshold) {
       activeName: active !== null ? active.name : null,
       count: accounts.accounts.length,
     },
+    // Wrapper provider routes (vision proxies etc.) the user has marked as
+    // official, plus the ones observed so far that are not official yet —
+    // the settings page turns these into checkboxes. Issue #21.
+    providers: {
+      builtinOfficial: OFFICIAL_PROVIDER,
+      official: [...store.officialProviders],
+      known: store.knownProviders.filter((p) => p !== OFFICIAL_PROVIDER && !store.officialProviders.includes(p)),
+    },
   }
 }
 
@@ -703,6 +738,24 @@ export function apply(ctx, config) {
       },
     })
     // -- multi-account routes -------------------------------------------------
+    // Configure which wrapper provider routes (vision proxies and the like)
+    // bill into the official bucket. Issue #21.
+    const disposeProviders = ctx.webServer.register({
+      kind: 'exact',
+      path: '/api/wallet/official-providers',
+      handler: async (req, res) => {
+        if (req.method !== 'POST') return json(res, 405, { ok: false, error: 'method-not-allowed' })
+        const body = await readBody(req)
+        if (body === null || !Array.isArray(body.providers)) return json(res, 400, { ok: false, error: 'providers array is required' })
+        store.officialProviders = normalizeProviderList(body.providers)
+        scheduleSave(ctx.logger)
+        return json(res, 200, {
+          ok: true,
+          official: [...store.officialProviders],
+          known: store.knownProviders.filter((p) => p !== OFFICIAL_PROVIDER && !store.officialProviders.includes(p)),
+        })
+      },
+    })
     const disposeAccounts = ctx.webServer.register({
       kind: 'exact',
       path: '/api/wallet/accounts',
@@ -766,6 +819,7 @@ export function apply(ctx, config) {
       disposeRefresh()
       disposeClear()
       disposeAccounts()
+      disposeProviders()
       disposeActivate()
       disposeRemove()
       clearInterval(balanceTimer)

--- a/lib/client.js
+++ b/lib/client.js
@@ -1073,6 +1073,43 @@ function fmtCurrency(value, currency) {
         React.createElement('span', { className: 'dshw_muted', style: { marginLeft: 'auto' } }, thresholdNotice)))
       rows.push(React.createElement('div', { key: 'setcard', className: 'dshw_setCard' }, cells))
 
+      // —— Provider 分桶（Issue #21：包装官方的路由勾选计入官方计费） ——
+      var knownProviders = snapshot && snapshot.providers && Array.isArray(snapshot.providers.known) ? snapshot.providers.known : []
+      var officialProviders = snapshot && snapshot.providers && Array.isArray(snapshot.providers.official) ? snapshot.providers.official : []
+      if (knownProviders.length > 0 || officialProviders.length > 0) {
+        rows.push(React.createElement('div', { key: 'pr-t', className: 'dshw_title', style: { marginTop: '8px' } }, 'Provider \u5206\u6876'))
+        var providerRows = officialProviders.map(function (p) {
+          return React.createElement('div', { key: 'op-' + p, className: 'dshw_setCell' },
+            React.createElement('label', { className: 'dshw_check', style: { margin: 0 } },
+              React.createElement('input', {
+                type: 'checkbox', checked: true,
+                'aria-label': p + ' \u8ba1\u5165\u5b98\u65b9',
+                onChange: function () {
+                  fetch('/api/wallet/official-providers', {
+                    method: 'POST',
+                    headers: { 'content-type': 'application/json' },
+                    body: JSON.stringify({ providers: officialProviders.filter(function (x) { return x !== p }) })
+                  }).then(reloadAccounts).catch(function () { /* ignore */ })
+                }
+              }), p + ' \u00b7 \u5b98\u65b9\u8ba1\u8d39'))
+        }).concat(knownProviders.map(function (p) {
+          return React.createElement('div', { key: 'kp-' + p, className: 'dshw_setCell' },
+            React.createElement('label', { className: 'dshw_check', style: { margin: 0 } },
+              React.createElement('input', {
+                type: 'checkbox', checked: false,
+                'aria-label': p + ' \u8ba1\u5165\u5b98\u65b9',
+                onChange: function () {
+                  fetch('/api/wallet/official-providers', {
+                    method: 'POST',
+                    headers: { 'content-type': 'application/json' },
+                    body: JSON.stringify({ providers: officialProviders.concat([p]) })
+                  }).then(reloadAccounts).catch(function () { /* ignore */ })
+                }
+              }), p + ' \u00b7 \u4e09\u65b9\u8ba1\u8d39'))
+        }))
+        rows.push(React.createElement('div', { key: 'pr-card', className: 'dshw_setCard', style: { display: 'block' } }, providerRows))
+      }
+
       // —— 账户管理 ——
       rows.push(React.createElement('div', { key: 'acc-t', className: 'dshw_title', style: { marginTop: '8px' } }, '\u8d26\u6237\u7ba1\u7406'))
       if (accountsError) {

--- a/test/wallet.test.mjs
+++ b/test/wallet.test.mjs
@@ -106,7 +106,9 @@ function loadClientBundle(React, globals = {}, windowOverrides = {}) {
 
 function createHookRenderer() {
   const hooks = []
+  const pendingEffects = []
   let cursor = 0
+  let effectsEnabled = false
   const React = {
     Fragment: Symbol('Fragment'),
     createElement(type, props, ...children) {
@@ -127,14 +129,27 @@ function createHookRenderer() {
         hooks[index] = typeof value === 'function' ? value(hooks[index]) : value
       }]
     },
-    useEffect() { cursor++ },
+    // Effects stay no-ops unless a test opts in via render(..., { flushEffects: true });
+    // collected callbacks then run right after the render pass so fetch-driven
+    // state can settle before a follow-up render.
+    useEffect(fn) {
+      const index = cursor++
+      if (effectsEnabled && !(index in hooks)) { hooks[index] = null; pendingEffects.push(fn) }
+      else if (!(index in hooks)) hooks[index] = null
+    },
     useLayoutEffect() { cursor++ },
   }
   return {
     React,
-    render(Component, props) {
+    render(Component, props, options) {
       cursor = 0
-      return Component(props)
+      effectsEnabled = !!(options && options.flushEffects)
+      const tree = Component(props)
+      if (pendingEffects.length > 0) {
+        const fns = pendingEffects.splice(0)
+        for (const fn of fns) fn()
+      }
+      return tree
     },
   }
 }
@@ -475,6 +490,8 @@ test('official cost is accumulated at usage time and remains stable later', () =
     version: 2,
     threshold: 5,
     sessions: { current: { official: bucket, third: { models: {} } } },
+    officialProviders: [],
+    knownProviders: [],
   }, bj(2026, 8, 19, 22, 0))
   assert.ok(Math.abs(normalized.store.sessions.current.official.cost - 54.45) < 1e-12)
   assert.equal(normalized.migrated, false)
@@ -1494,4 +1511,50 @@ test('session cost follows the active account currency with a marked estimate', 
   const Section = exports.__testing.WalletSettingsSection
   const tree = renderer.render(Section, { close: () => {} })
   assert.ok(tree, 'the settings section still renders')
+})
+
+test('findAccount resolves stored accounts and nulls for unknown ids', async () => {
+  const mod = await freshAccountsModule()
+  const a = mod.addAccount('Alice', 'sk-alice-1234567890').account
+  mod.addAccount('Bob', 'sk-bob-1234567890')
+  assert.equal(mod.findAccount(a.id).name, 'Alice')
+  assert.equal(mod.findAccount('acc_missing'), null)
+})
+
+test('settings section renders populated data from the wallet APIs', async () => {
+  const renderer = createHookRenderer()
+  const mockFetch = (url) => Promise.resolve({
+    ok: true,
+    json: () => Promise.resolve(
+      String(url).includes('/accounts')
+        ? { ok: true, activeId: 'acc_1', accounts: [{ id: 'acc_1', name: '主账户', maskedKey: 'sk-0***d649', active: true }] }
+        : { ok: true, balance: { available: true, total: 1.98, currency: 'USD' }, lowBalance: false, threshold: 3, accounts: { activeId: 'acc_1', activeName: '主账户', count: 1 }, session: { official: { cost: 0.05 } } }
+    ),
+  })
+  const { exports } = loadClientBundle(renderer.React, { fetch: mockFetch })
+  const Section = exports.__testing.WalletSettingsSection
+  // First render with effect flush: the fetches fire right after the pass.
+  renderer.render(Section, { close: () => {} }, { flushEffects: true })
+  await new Promise((resolve) => setTimeout(resolve, 30)) // let the responses settle into state
+  const tree = renderer.render(Section, { close: () => {} })
+  const text = JSON.stringify(tree)
+  assert.ok(text.includes('主账户'), 'the account row must render from live data')
+  assert.ok(/1.98/.test(text), 'the balance figure must render')
+})
+
+test('provider aliasing: wrapper routes can join the official bucket (Issue #21)', async () => {
+  const { isOfficialProvider, normalizeProviderList, normalizeStoreData } = await import('../index.js')
+  assert.equal(isOfficialProvider('deepseek-official'), true)
+  assert.equal(isOfficialProvider('deepseek-official', []), true)
+  assert.equal(isOfficialProvider('deepseek-vision'), false)
+  assert.equal(isOfficialProvider('deepseek-vision', ['deepseek-vision']), true, 'a whitelisted wrapper route must bill officially')
+  assert.equal(isOfficialProvider('deepseek-vision', 'deepseek-vision'), false, 'a non-array whitelist must not match')
+
+  assert.deepEqual(normalizeProviderList(null), [])
+  assert.deepEqual(normalizeProviderList(['a', 'a', 'deepseek-official', 42, '']), ['a'], 'dedupe, drop junk and the builtin name')
+  const withProviders = normalizeStoreData({ officialProviders: ['deepseek-vision'], knownProviders: ['deepseek-vision'] })
+  assert.deepEqual(withProviders.store.officialProviders, ['deepseek-vision'])
+  assert.deepEqual(withProviders.store.knownProviders, ['deepseek-vision'])
+  const bare = normalizeStoreData({})
+  assert.deepEqual(bare.store.officialProviders, [], 'old stores migrate with empty provider lists')
 })


### PR DESCRIPTION
## 修复 / Fix

dsh-vision-proxy 等包装官方的路由（provider 名不同但实际打官方 API）此前全部计入三方桶。现在：

- 分桶改为可配置集合，不再硬编码单个名字 / Bucket membership is a configured set
- 自动记录出现过的 provider，设置页「Provider 分桶」勾选即计入官方（按官方价格计费）/ Observed providers surface as checkboxes in the settings page; checked ones bill officially
- 存量数据自动迁移，白名单持久化 / Old stores migrate; the list persists

Fixes #21, reported by @wenjie0112. 57/57 tests pass.