### PR TITLE
fix: fresh stores default the provider lists (CI red from #24)

### DIFF
--- a/index.js
+++ b/index.js
@@ -201,7 +201,7 @@ function loadStore() {
     return normalizeStoreData(JSON.parse(readFileSync(STORE_PATH, 'utf8')))
   } catch {
     return {
-      store: { version: STORE_VERSION, threshold: DEFAULT_THRESHOLD, sessions: {} },
+      store: { version: STORE_VERSION, threshold: DEFAULT_THRESHOLD, sessions: {}, officialProviders: [], knownProviders: [] },
       migrated: false,
     }
   }


### PR DESCRIPTION
\u7a7a\u73af\u5883\u9ed8\u8ba4 store \u8865\u9f50 provider \u5b57\u6bb5\uff0c\u672c\u5730\u7528\u7a7a HOME \u6a21\u62df CI \u9a8c\u8bc1 57/57\u3002/ Empty-store default carries the provider lists; verified with an empty DSH_HOME.