### PR TITLE
release: v0.2.3 billing and account fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project are documented in this file.
 
+## 0.2.3 - 2026-08-21
+
+- 修复 Provider 分桶实际未参与计费的问题；已勾选的包装路由现在真正进入官方 token/花费桶，并记录新观察到的 Provider。 / Fixed provider aliases not reaching the billing path: opted-in wrapper routes now enter the official token/cost bucket, and newly observed providers are recorded.
+- 修复首次添加账户时凭证同步失败仍显示为当前账户的问题；失败会回滚激活状态。 / Rolled back first-account activation when the host refuses credential synchronization.
+- 修复删除账户后账户专属阈值未写回钱包存储的问题。 / Persisted removal of account-specific thresholds when an account is deleted.
+- 余额错误改为安全枚举，避免把上游错误原文暴露到浏览器；美元/多余额记录的明细选择也统一。 / Replaced raw balance errors with safe enums and aligned multi-currency balance selection.
+- 统一提醒设置的本地存储格式，并兼容旧的毫秒字段；API Key 输入框默认隐藏。 / Unified reminder storage with migration from the legacy millisecond field and made API-key inputs password fields.
+
 ## 0.2.2 - 2026-08-20
 
 - 新增 24h 峰谷计费分时时钟：在侧边栏左下角常驻展示当前时段（高峰/低谷半价）、剩余倒计时、实时余额与本场/本约花费；折叠导轨模式下自动收拢为 42px 紧凑环形钟。 / Added a 24h peak/off-peak ring clock in the sidebar footer: live pricing window (peak / 50% off-peak), switch countdown, live balance and session spend; collapses into a 42px compact circle in rail mode.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![npm version](https://img.shields.io/npm/v/deepseek-harness-wallet?label=npm&color=5965d8)](https://www.npmjs.com/package/deepseek-harness-wallet)
 [![GitHub release](https://img.shields.io/github/v/release/feibi-mochi/deepseek-harness-control-center?label=release&color=5965d8)](https://github.com/feibi-mochi/deepseek-harness-control-center/releases)
 [![CI](https://github.com/feibi-mochi/deepseek-harness-control-center/actions/workflows/validate.yml/badge.svg)](https://github.com/feibi-mochi/deepseek-harness-control-center/actions/workflows/validate.yml)
-[![DeepSeek Harness](https://img.shields.io/badge/DeepSeek%20Harness-0.1.0--rc.6-4aa3ff)](https://github.com/deepseek-ai/DeepSeek-Harness)
+[![DeepSeek Harness](https://img.shields.io/badge/DeepSeek%20Harness-0.1.0--rc.8-4aa3ff)](https://github.com/deepseek-ai/DeepSeek-Harness)
 [![License: MIT](https://img.shields.io/badge/license-MIT-3b7a57)](./LICENSE)
 
 **DeepSeek Harness monitoring, alerts, recharge, and session control center.**
@@ -25,7 +25,8 @@
 - **Official DeepSeek** — live balance (60s global refresh with fast boot retries), current-session cost locked to the price active for each usage event (including the 2026-08-17 peak/off-peak rollout), and token breakdown.
 - **24h peak/off-peak ring clock** — resident sidebar footer widget indicating real-time pricing windows (peak vs. 50% discount off-peak), countdown to next switch, and optional desktop switch notifications.
 - **Third-party total** — current-session tokens (input / cache read / output). No balance guessing, no cost math, zero configuration.
-- **Click the chip** to open the detail panel: correctly formatted per-currency balances, cost and token splits, a freely editable low-balance threshold in CNY (two decimals, persisted globally; alerts only compare a CNY balance and never mix currencies), manual refresh, and a jump to the official recharge page (first click shows the domain for confirmation — anti-phishing).
+- **Provider classification** — observed wrapper routes appear in the settings page; opted-in routes join the official token/cost bucket and are priced with the official table.
+- **Click the chip** to open the detail panel: correctly formatted per-currency balances, cost and token splits, a freely editable low-balance threshold for the active account and currency (two decimals, persisted per account; alerts never mix currencies), manual refresh, and a jump to the official recharge page (first click shows the domain for confirmation — anti-phishing).
 - **Move, dock, and scale** — drag the chip freely, preview nearby snap targets, use compact horizontal or vertical layouts, adjust its scale from the control panel, and show official or third-party data independently. The choices are remembered locally.
 - **Floating window mode** — detach the detail panel into a draggable window with a remembered position, or minimize it directly to a freely movable dot; the dot turns red below the threshold.
 - **Completion reminders** — optionally notify when a conversation finishes, with persistent or timed modes, queueing and deduplication for simultaneous completions, cross-tab coordination, and an in-page fallback when system notifications are unavailable.
@@ -127,7 +128,7 @@ For buildable DSH hosts, the npm package and repository include a versioned [Age
 
 | Item | Behavior |
 | --- | --- |
-| Token accounting | Listens to the `llm/stream` event and buckets per provider (`deepseek-official` vs. everything else) and per session; each usage event also locks its contemporaneous official price, so multiple sessions and pricing windows never mix. |
+| Token accounting | Listens to the `llm/stream` event and buckets per session and provider: `deepseek-official` plus explicitly opted-in wrapper routes use the official bucket; other providers stay third-party; each usage event also locks its contemporaneous official price, so multiple sessions and pricing windows never mix. |
 | Balance | The key from the credentials seam (or the active account's key) never leaves this machine except as the `Authorization` header of the official `/user/balance` request. |
 | Accounts | Keys live in `$DSH_HOME/storages/accounts.json` (plaintext, matching the harness's own credential storage); the UI only ever shows masked keys, and switching writes the chosen key into the credentials seam for LLM billing. |
 | Session log | The plugin writes no events; its data lives in `$DSH_HOME/storages/wallet.json`. |

--- a/RELEASE-NOTES-v0.2.3.md
+++ b/RELEASE-NOTES-v0.2.3.md
@@ -1,0 +1,33 @@
+## 中文
+
+**v0.2.3 是一次计费归属、账户状态与多币种显示的可靠性修复。**
+
+- **Provider 分桶真正生效**：在设置页勾选的包装 Provider 现在会进入官方 token/花费桶，并按官方价格表计费；新观察到的 Provider 会自动出现在设置中。
+- **账户状态不再错报**：首次添加账户时若宿主拒绝写入凭证，插件会回滚激活状态，不再显示与实际 LLM 计费账户不一致的“当前账户”。
+- **账户阈值正确清理**：删除账户时，其独立低余额阈值会同步从钱包存储中持久化删除。
+- **多币种余额一致**：充值、赠送和余额摘要统一使用服务端选中的币种记录，避免接口记录顺序造成 USD/CNY 明细错配。
+- **错误信息更安全**：浏览器只接收安全错误枚举，不再显示上游原始错误；低余额提醒也会按当前币种格式化。
+- **设置同步与隐私**：完成提醒统一使用同一存储结构并自动迁移旧数据；API Key 输入框默认隐藏。
+- **测试增强**：新增 Provider 实际计费、账户激活回滚、阈值持久化、安全错误、多币种选择和输入框隐私回归测试，当前 70/70 全绿。
+
+**升级**：`dsh plugin --profile web update deepseek-harness-wallet`，重启 `dsh web` 后强制刷新页面。
+
+**兼容**：已在 DeepSeek Harness `0.1.0-rc.8`、Windows + Edge 实测；CI 覆盖 Ubuntu/macOS/Windows × Node 22.19/24。
+
+---
+
+## English
+
+**v0.2.3 is a reliability release for billing attribution, account state, and multi-currency display.**
+
+- **Provider classification now reaches billing** — opted-in wrapper providers enter the official token/cost bucket and use the official price table; newly observed providers appear automatically in settings.
+- **Account state no longer overclaims activation** — if the host refuses the first credential write, the plugin rolls back the active account instead of displaying a billing account the LLM route is not using.
+- **Account thresholds are cleaned up durably** — deleting an account now persists removal of its account-specific low-balance threshold.
+- **Consistent multi-currency balances** — balance, topped-up, and granted figures use the server-selected currency record rather than depending on response order.
+- **Safer browser errors** — the client receives bounded error enums instead of raw upstream error text, and low-balance notifications use the active currency.
+- **Settings sync and privacy** — completion reminders share one canonical storage shape with legacy migration, and API-key inputs are password fields by default.
+- **Stronger regression coverage** — added end-to-end provider billing, activation rollback, threshold persistence, safe error, currency-selection, and input-privacy tests; 70/70 tests pass.
+
+**Upgrade**: `dsh plugin --profile web update deepseek-harness-wallet`, restart `dsh web`, then hard-refresh the page.
+
+**Compatibility**: verified with DeepSeek Harness `0.1.0-rc.8` on Windows + Edge; CI covers Ubuntu/macOS/Windows × Node 22.19/24.

--- a/docs/i18n/README.zh-CN.md
+++ b/docs/i18n/README.zh-CN.md
@@ -3,7 +3,7 @@
 [![npm 版本](https://img.shields.io/npm/v/deepseek-harness-wallet?label=npm&color=5965d8)](https://www.npmjs.com/package/deepseek-harness-wallet)
 [![GitHub Release](https://img.shields.io/github/v/release/feibi-mochi/deepseek-harness-control-center?label=release&color=5965d8)](https://github.com/feibi-mochi/deepseek-harness-control-center/releases)
 [![构建检查](https://github.com/feibi-mochi/deepseek-harness-control-center/actions/workflows/validate.yml/badge.svg)](https://github.com/feibi-mochi/deepseek-harness-control-center/actions/workflows/validate.yml)
-[![DeepSeek Harness](https://img.shields.io/badge/DeepSeek%20Harness-0.1.0--rc.6-4aa3ff)](https://github.com/deepseek-ai/DeepSeek-Harness)
+[![DeepSeek Harness](https://img.shields.io/badge/DeepSeek%20Harness-0.1.0--rc.8-4aa3ff)](https://github.com/deepseek-ai/DeepSeek-Harness)
 [![MIT 许可证](https://img.shields.io/badge/license-MIT-3b7a57)](../../LICENSE)
 
 **DeepSeek Harness 监控、提醒、充值与会话控制中心。**
@@ -25,7 +25,8 @@
 - **官方 DeepSeek**——余额（60 秒全局刷新 + 启动快速重试）、本会话花费（每次用量按发生时价格锁定，含 2026-08-17 峰谷价）、token 拆分。
 - **24h 峰谷计费分时时钟**——侧边栏底部常驻环形钟，实时呈现当前时段（高峰/低谷半价优惠）、下一次切换倒计时与系统级桌面切换提醒。
 - **第三方合计**——本会话 token（输入 / 缓存读 / 输出）。不算钱、不猜余额、零配置。
-- **点开面板**——按币种正确显示符号的余额拆分、花费与 token 明细、可自由填写的低余额阈值（人民币、两位小数、全局持久化；仅在有人民币余额时提醒，绝不跨币种比较或相加）、手动刷新、跳转官方充值页（首次点击显示域名确认，防钓鱼）。
+- **Provider 分桶**——设置页会列出已观察到的包装路由；勾选后计入官方 token/花费桶，并按官方价格表计费。
+- **点开面板**——按币种正确显示符号的余额拆分、花费与 token 明细、可自由填写当前账户与币种的低余额阈值（两位小数、按账户持久化；绝不跨币种比较或相加）、手动刷新、跳转官方充值页（首次点击显示域名确认，防钓鱼）。
 - **移动、吸附与缩放**——标签可自由拖动，靠近目标区域时预览吸附位置，按空间切换紧凑横排或竖排；还可在控制面板中调整比例，并分别显示官方或第三方数据。设置均保存在本地。
 - **悬浮窗口**——明细面板可切换为位置记忆的拖动窗口，也可直接最小化为自由移动的圆点；低于阈值时圆点变红。
 - **对话完成提醒**——可选择常驻或定时关闭；多个对话同时完成时自动排队、去重，并协调多个标签页；系统通知不可用时改用页面内提醒。
@@ -127,7 +128,7 @@ window.__DSH_WALLET_ADAPTER__ = {
 
 | 项目 | 行为 |
 | --- | --- |
-| Token 计费 | 监听 `llm/stream` 事件，按 provider 分桶（`deepseek-official` 之外全部归第三方）、按会话隔离；每次用量同时锁定当时的官方价格，会话与峰谷时段都不串账。 |
+| Token 计费 | 监听 `llm/stream` 事件，按会话和 provider 分桶：`deepseek-official` 及明确勾选的包装路由进入官方桶，其他 provider 保持第三方桶；每次用量同时锁定当时的官方价格，会话与峰谷时段都不串账。 |
 | 余额 | 凭证库（或当前账户）的 key 只在本机流转，仅作为 `Authorization` 头发往官方 `/user/balance` 接口。 |
 | 账户 | key 存于 `$DSH_HOME/storages/accounts.json`（明文，与 harness 自身凭证存储一致）；界面只显示掩码，切换会把所选 key 写入凭证库用于 LLM 计费。 |
 | 会话日志 | 插件不写入任何事件；数据存于 `$DSH_HOME/storages/wallet.json`。 |

--- a/index.js
+++ b/index.js
@@ -386,16 +386,18 @@ export function removeAccount(id) {
   const index = accounts.accounts.findIndex((account) => account.id === id)
   if (index < 0) return { ok: false, error: 'account not found' }
   accounts.accounts.splice(index, 1)
-  // Drop the account's own threshold line along with it.
+  // Drop the account's own threshold line along with it. The caller persists
+  // wallet.json separately from accounts.json when this flag is true.
+  let thresholdRemoved = false
   if (store.accountThresholds && Object.hasOwn(store.accountThresholds, id)) {
     delete store.accountThresholds[id]
-    scheduleAccountsSave(null)
+    thresholdRemoved = true
   }
   // Deliberately NOT unsetting the credentials seam: the key currently in
   // .credentials.yaml keeps working for LLM billing; the UI just reports
   // "no active account" and balance falls back to the seam key.
   if (accounts.activeId === id) accounts.activeId = null
-  return { ok: true }
+  return { ok: true, thresholdRemoved }
 }
 
 export function accountListView() {
@@ -485,12 +487,18 @@ function recordUsage(options, usage, atMs = Date.now()) {
   if (typeof sessionId !== 'string' || sessionId === '' || typeof provider !== 'string' || provider === '') return
   if (typeof model !== 'string' || model === '__proto__' || model === 'prototype' || model === 'constructor') return
   if (sessionId === '__proto__' || sessionId === 'prototype' || sessionId === 'constructor') return
+  // Remember every non-builtin route observed by the stream tap. The settings
+  // page can then promote wrapper routes into the official billing bucket.
+  if (provider !== OFFICIAL_PROVIDER && !store.knownProviders.includes(provider)) {
+    store.knownProviders = normalizeProviderList([...store.knownProviders, provider])
+  }
   if (!Object.hasOwn(store.sessions, sessionId)) {
     store.sessions[sessionId] = { official: emptyBucket(true), third: emptyBucket(false) }
   }
   const session = store.sessions[sessionId]
-  const bucket = provider === OFFICIAL_PROVIDER ? session.official : session.third
-  if (provider === OFFICIAL_PROVIDER) addOfficialUsage(bucket, model, usage, atMs)
+  const official = isOfficialProvider(provider, store.officialProviders)
+  const bucket = official ? session.official : session.third
+  if (official) addOfficialUsage(bucket, model, usage, atMs)
   else {
     if (!Object.hasOwn(bucket.models, model)) bucket.models[model] = emptyCounters()
     addUsage(bucket.models[model], usage)
@@ -503,13 +511,13 @@ let balanceRefresh = null
 async function performBalanceRefresh(ctx) {
   const credentials = ctx.get('credentials')
   if (credentials === undefined) {
-    balance = { fetchedAt: Date.now(), available: false, balances: [], error: 'no credentials service' }
+    balance = { fetchedAt: Date.now(), available: false, balances: [], error: 'no-credentials' }
     return
   }
   try {
     const key = await resolveBalanceKey(ctx)
     if (key === undefined || key === '') {
-      balance = { fetchedAt: Date.now(), available: false, balances: [], error: 'no API key' }
+      balance = { fetchedAt: Date.now(), available: false, balances: [], error: 'no-api-key' }
       return
     }
     const controller = new AbortController()
@@ -520,23 +528,36 @@ async function performBalanceRefresh(ctx) {
         headers: { authorization: 'Bearer ' + key },
         signal: controller.signal,
       })
-      if (!response.ok) throw new Error('status ' + response.status)
+      if (!response.ok) {
+        const code = response.status === 401 || response.status === 403
+          ? 'unauthorized'
+          : response.status === 429 ? 'rate-limited' : 'upstream-unavailable'
+        const error = new Error(code)
+        error.code = code
+        throw error
+      }
       const data = await response.json()
+      const available = data !== null && typeof data === 'object' && data.is_available === true
       balance = {
         fetchedAt: Date.now(),
-        available: data.is_available === true,
-        balances: Array.isArray(data.balance_infos) ? data.balance_infos : [],
-        error: null,
+        available,
+        balances: available && Array.isArray(data.balance_infos) ? data.balance_infos : [],
+        error: available ? null : 'balance-unavailable',
       }
     } finally {
       clearTimeout(timer)
     }
   } catch (error) {
+    const code = error && typeof error === 'object' && typeof error.code === 'string'
+      ? error.code
+      : error && typeof error === 'object' && error.name === 'AbortError'
+        ? 'timeout'
+        : error instanceof SyntaxError ? 'invalid-response' : 'upstream-unavailable'
     balance = {
       fetchedAt: Date.now(),
       available: false,
       balances: [],
-      error: error instanceof Error ? error.message : String(error),
+      error: code,
     }
   }
 }
@@ -836,7 +857,8 @@ export function apply(ctx, config) {
         if (body === null || typeof body.name !== 'string' || typeof body.apiKey !== 'string') {
           return json(res, 400, { ok: false, error: 'name and apiKey are required' })
         }
-        const needSync = accounts.activeId === null
+        const previousActiveId = accounts.activeId
+        const needSync = previousActiveId === null
         const result = addAccount(body.name, body.apiKey)
         if (!result.ok) return json(res, 400, { ok: false, error: result.error })
         scheduleAccountsSave(ctx.logger)
@@ -844,6 +866,13 @@ export function apply(ctx, config) {
         if (needSync) {
           // First account: activate it so the LLM seam follows the new key.
           sync = await activateAccount(ctx, result.account.id)
+          // addAccount marks the first row active optimistically. If the host
+          // refuses the credential write, roll it back so UI/balance state does
+          // not claim a billing account that the LLM route is not using.
+          if (!sync.ok && accounts.activeId === result.account.id) {
+            accounts.activeId = previousActiveId
+            scheduleAccountsSave(ctx.logger)
+          }
         }
         return json(res, 200, {
           ok: true,
@@ -884,6 +913,7 @@ export function apply(ctx, config) {
         const result = removeAccount(body.id)
         if (!result.ok) return json(res, 400, { ok: false, error: result.error })
         scheduleAccountsSave(ctx.logger)
+        if (result.thresholdRemoved) scheduleSave(ctx.logger)
         return json(res, 200, { ok: true, ...accountListView() })
       },
     })

--- a/lib/client.js
+++ b/lib/client.js
@@ -14,7 +14,7 @@ window.__ModuleLoader__.load({
 
     var POLL_MS = 15000
     // Keep in lockstep with package.json; a test enforces the sync.
-    var WALLET_VERSION = '0.2.2'
+    var WALLET_VERSION = '0.2.3'
     var CONFIRM_KEY = 'dsh-wallet-recharge-confirmed'
     var CHIP_LAYOUT_KEY = 'dshw-chip-layout-v4'
     var PANEL_POS_KEY = 'dshw-panel-pos-v1'
@@ -599,6 +599,32 @@ window.__ModuleLoader__.load({
       }
     }
 
+    function selectBalanceInfo(balance) {
+      if (!balance || !Array.isArray(balance.balances) || balance.balances.length === 0) return null
+      var currency = typeof balance.currency === 'string' ? balance.currency.toUpperCase() : null
+      if (currency) {
+        var matching = balance.balances.find(function (info) {
+          return info && typeof info.currency === 'string' && info.currency.toUpperCase() === currency
+        })
+        if (matching) return matching
+      }
+      return balance.balances[0]
+    }
+
+    function balanceErrorText(error) {
+      switch (error) {
+        case 'no-credentials': return '宿主凭证服务不可用'
+        case 'no-api-key': return '未配置 DeepSeek API Key'
+        case 'unauthorized': return 'API Key 无效或已过期'
+        case 'rate-limited': return '余额接口请求过于频繁'
+        case 'timeout': return '余额接口请求超时'
+        case 'invalid-response': return '余额接口返回无效数据'
+        case 'balance-unavailable': return '余额暂不可用'
+        case 'upstream-unavailable': return '余额接口暂时不可用'
+        default: return '余额暂不可用'
+      }
+    }
+
     function computePanelPosition(chipRect, panelRect, viewportWidth, viewportHeight) {
       var margin = 8
       var gap = 6
@@ -664,6 +690,11 @@ window.__ModuleLoader__.load({
     function normalizeNotifyConfig(value) {
       var enabled = !value || value.enabled !== false
       var timeout = value && Number.parseInt(value.timeout, 10)
+      // Migrate the brief settings-page schema that stored milliseconds under
+      // autoCloseMs. The canonical shared shape is { enabled, timeout }.
+      if ([0, 5, 10, 30, 60].indexOf(timeout) === -1 && value && Object.hasOwn(value, 'autoCloseMs')) {
+        timeout = value.autoCloseMs === null ? 0 : Math.round(Number(value.autoCloseMs) / 1000)
+      }
       if ([0, 5, 10, 30, 60].indexOf(timeout) === -1) timeout = 10
       return { enabled: enabled, timeout: timeout }
     }
@@ -722,7 +753,7 @@ window.__ModuleLoader__.load({
         }
         var item = active.item
         var remaining = queue.length
-        var body = item.title + (remaining > 0 ? '\n另有 ' + remaining + ' 个对话等待提醒' : '\n点击打开该对话')
+        var body = item.title + (remaining > 0 ? '\r\n另有 ' + remaining + ' 个对话等待提醒' : '\r\n点击打开该对话')
         if (active.timer !== null) clearTimeout(active.timer)
         if (active.notification) {
           active.notification.onclose = null
@@ -1051,7 +1082,7 @@ window.__ModuleLoader__.load({
       var [notifyEnabled, setNotifyEnabled] = React.useState(function () { return readNotifyConfig().enabled })
       var [notifyTimeout, setNotifyTimeout] = React.useState(function () {
         var cfg = readNotifyConfig()
-        return cfg.autoCloseMs === null ? 'keep' : String(Math.round(cfg.autoCloseMs / 1000))
+        return cfg.timeout === 0 ? 'keep' : String(cfg.timeout)
       })
       var [lowBlinkEnabled, setLowBlinkEnabled] = React.useState(function () {
         try { return compatibility.storage.getItem(LOW_BLINK_KEY) !== 'false' } catch (e) { return true }
@@ -1120,13 +1151,13 @@ window.__ModuleLoader__.load({
       }
 
       function persistNotify(enabled, timeout) {
-        var autoCloseMs = timeout === 'keep' ? null : Number.parseInt(timeout, 10) * 1000
-        if (!Number.isFinite(autoCloseMs) && timeout !== 'keep') autoCloseMs = 10000
+        var timeoutSeconds = timeout === 'keep' ? 0 : Number.parseInt(timeout, 10)
+        if ([0, 5, 10, 30, 60].indexOf(timeoutSeconds) === -1) timeoutSeconds = 10
         try {
-          compatibility.storage.setItem(NOTIFY_CONFIG_KEY, JSON.stringify({ enabled: enabled, autoCloseMs: autoCloseMs }))
+          compatibility.storage.setItem(NOTIFY_CONFIG_KEY, JSON.stringify({ enabled: enabled, timeout: timeoutSeconds }))
         } catch (e) { /* ignore */ }
         setNotifyEnabled(enabled)
-        setNotifyTimeout(timeout)
+        setNotifyTimeout(timeoutSeconds === 0 ? 'keep' : String(timeoutSeconds))
         compatibility.dispatch(NOTIFY_CONFIG_EVENT)
       }
 
@@ -1224,7 +1255,7 @@ window.__ModuleLoader__.load({
       var lowBalance = snapshot && snapshot.lowBalance === true
       var sessionCost = snapshot && snapshot.session && snapshot.session.official && snapshot.session.official.cost !== null && snapshot.session.official.cost !== undefined ? sessionCostText(snapshot.session.official.cost, snapshot && snapshot.balance ? snapshot.balance.currency : null) : '--'
       var currencyCode = bal && typeof bal.currency === 'string' ? bal.currency : 'CNY'
-      var primaryBalance = bal && Array.isArray(bal.balances) && bal.balances.length > 0 ? bal.balances[0] : null
+      var primaryBalance = selectBalanceInfo(bal)
       var toppedText = primaryBalance ? fmtCurrency(primaryBalance.topped_up_balance, primaryBalance.currency) : '--'
       var grantedText = primaryBalance ? fmtCurrency(primaryBalance.granted_balance, primaryBalance.currency) : '--'
       rows.push(React.createElement('div', { key: 'head', className: 'dshw_settingsHeader' },
@@ -1477,7 +1508,7 @@ window.__ModuleLoader__.load({
           onChange: function (event) { setNameDraft(event.target.value) }
         }),
         React.createElement('input', {
-          className: 'dshw_input',
+          className: 'dshw_input', type: 'password',
           placeholder: 'sk-...', 'aria-label': 'API Key',
           value: keyDraft,
           onInput: function (event) { setKeyDraft(event.target.value) },
@@ -1952,7 +1983,8 @@ window.__ModuleLoader__.load({
             if (showOfficial && json.lowBalance) {
               if (!notifiedRef.current) {
                 try {
-                  var lowNotice = compatibility.notify('DeepSeek \u4f59\u989d\u4e0d\u8db3', { body: '\u4f59\u989d\u5df2\u4f4e\u4e8e\u63d0\u9192\u7ebf ' + json.threshold + ' \u5143', tag: 'dsh-wallet-low' })
+                  var lowCurrency = json.balance && json.balance.currency ? json.balance.currency : 'CNY'
+                  var lowNotice = compatibility.notify('DeepSeek 余额不足', { body: '余额已低于提醒线 ' + fmtCurrency(json.threshold, lowCurrency), tag: 'dsh-wallet-low' })
                   if (lowNotice) notifiedRef.current = true
                 } catch (e) { /* ignore */ }
               }
@@ -2554,7 +2586,7 @@ window.__ModuleLoader__.load({
 
       function activateAccount(id, name) {
         if (switchingId !== null) return
-        if (!window.confirm('\u5207\u6362\u5230\u8d26\u6237\u300c' + name + '\u300d\uff1f\n\u5207\u6362\u540e\uff0c\u540e\u7eed LLM \u8bf7\u6c42\u5c06\u4f7f\u7528\u8be5\u8d26\u6237\u7684 Key \u8ba1\u8d39\u3002')) return
+        if (!window.confirm('\u5207\u6362\u5230\u8d26\u6237\u300c' + name + '\u300d\uff1f\r\n\u5207\u6362\u540e\uff0c\u540e\u7eed LLM \u8bf7\u6c42\u5c06\u4f7f\u7528\u8be5\u8d26\u6237\u7684 Key \u8ba1\u8d39\u3002')) return
         setSwitchingId(id)
         setAccountNotice(null)
         fetch('/api/wallet/accounts/activate', {
@@ -2585,7 +2617,7 @@ window.__ModuleLoader__.load({
       }
 
       function removeAccount(id, name) {
-        if (!window.confirm('\u5220\u9664\u8d26\u6237\u300c' + name + '\u300d\uff1f\n\u4ec5\u5220\u9664\u672c\u63d2\u4ef6\u7684\u8d26\u6237\u8bb0\u5f55\uff0c\u4e0d\u5f71\u54cd .credentials.yaml \u4e2d\u5df2\u6709\u7684 Key\u3002')) return
+        if (!window.confirm('\u5220\u9664\u8d26\u6237\u300c' + name + '\u300d\uff1f\r\n\u4ec5\u5220\u9664\u672c\u63d2\u4ef6\u7684\u8d26\u6237\u8bb0\u5f55\uff0c\u4e0d\u5f71\u54cd .credentials.yaml \u4e2d\u5df2\u6709\u7684 Key\u3002')) return
         fetch('/api/wallet/accounts/remove', {
           method: 'POST',
           headers: { 'content-type': 'application/json' },
@@ -2868,7 +2900,7 @@ window.__ModuleLoader__.load({
         type: 'number',
         min: '0',
         step: 'any',
-        'aria-label': '\u4f59\u989d\u63d0\u9192\u9608\u503c\uff08CNY\uff09',
+        'aria-label': '余额提醒阈值（' + (bal.currency || 'CNY') + '）',
         value: thresholdDraft === null ? '' : thresholdDraft,
         onChange: function (event) {
           thresholdInitializedRef.current = 'editing'
@@ -3003,10 +3035,10 @@ window.__ModuleLoader__.load({
       function balanceCard() {
         if (!bal.available || !bal.balances || bal.balances.length === 0) {
           return React.createElement('div', { className: 'dshw_balanceCard' },
-            React.createElement('div', { className: 'dshw_muted' }, bal.error ? ('\u4f59\u989d\u4e0d\u53ef\u7528: ' + bal.error) : '\u4f59\u989d\u67e5\u8be2\u4e2d\u2026'))
+            React.createElement('div', { className: 'dshw_muted' }, bal.error ? balanceErrorText(bal.error) : '余额查询中…'))
         }
-        var first = bal.balances[0]
-        var others = bal.balances.slice(1)
+        var first = selectBalanceInfo(bal)
+        var others = bal.balances.filter(function (info) { return info !== first })
         var subParts = [
           React.createElement('span', { key: 'top' }, '\u5145\u503c ' + fmtCurrency(first.topped_up_balance, first.currency)),
           React.createElement('span', { key: 'd1', className: 'dshw_balDot' }, '\u00b7'),
@@ -3022,7 +3054,7 @@ window.__ModuleLoader__.load({
           React.createElement('div', { className: 'dshw_balLine' },
             React.createElement('span', { className: 'dshw_muted' }, '\u4f59\u989d'),
             React.createElement('span', { className: 'dshw_balNum' }, fmtCurrency(first.total_balance, first.currency)),
-            low ? React.createElement('span', { className: 'dshw_balWarn', title: '\u4f4e\u4e8e\u63d0\u9192\u9608\u503c \u00a5' + (snapshot.threshold !== undefined ? snapshot.threshold : '') }, '\u4f59\u989d\u504f\u4f4e') : null),
+            low ? React.createElement('span', { className: 'dshw_balWarn', title: '低于提醒阈值 ' + fmtCurrency(snapshot.threshold !== undefined ? snapshot.threshold : 0, bal.currency || 'CNY') }, '余额偏低') : null),
           React.createElement('div', { className: 'dshw_balSub' },
             sessionCostLabel(bal.currency) + ' ' + (official.cost === null ? '--' : sessionCostText(official.cost, bal.currency)),
             React.createElement('span', { className: 'dshw_balDot' }, '\u00b7'),
@@ -3219,7 +3251,7 @@ window.__ModuleLoader__.load({
           permanentDeleteControl,
           showOfficial ? React.createElement(React.Fragment, null,
             React.createElement('div', { className: 'dshw_row' },
-              React.createElement('span', { className: 'dshw_muted' }, '阈值(¥,0=关)'),
+              React.createElement('span', { className: 'dshw_muted' }, '阈值(' + (bal.currency || 'CNY') + ',0=关)'),
               thresholdInput),
             React.createElement('div', { className: 'dshw_row' },
               React.createElement('button', { type: 'button', className: 'dshw_btn', onClick: refreshBalance }, '刷新'),
@@ -3300,6 +3332,8 @@ window.__ModuleLoader__.load({
       computePanelPosition: computePanelPosition,
       createCompatibilityAdapter: createCompatibilityAdapter,
       fmtCurrency: fmtCurrency,
+      selectBalanceInfo: selectBalanceInfo,
+      balanceErrorText: balanceErrorText,
       installCompletionNotifier: installCompletionNotifier,
       normalizeDataVisibility: normalizeDataVisibility,
       normalizeNotifyConfig: normalizeNotifyConfig,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepseek-harness-wallet",
   "description": "Local-first account monitoring, usage accounting, official recharge, completion reminders, flexible layout, host-gated session controls, and multi-account management with hot account switching for DeepSeek Harness.",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "type": "module",
   "main": "index.js",
   "exports": {

--- a/test/wallet.test.mjs
+++ b/test/wallet.test.mjs
@@ -6,7 +6,7 @@ import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import { createHash } from 'node:crypto'
 import { EventEmitter } from 'node:events'
-import { existsSync, mkdtempSync, readFileSync } from 'node:fs'
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -233,7 +233,7 @@ test('release READMEs use only approved status badges and every local Markdown t
 test('release identity and intended npm archive inventory stay aligned', () => {
   const pkg = JSON.parse(readProjectFile('package.json'))
   assert.equal(pkg.name, 'deepseek-harness-wallet')
-  assert.equal(pkg.version, '0.2.2')
+  assert.equal(pkg.version, '0.2.3')
   assert.equal(pkg.main, 'index.js')
   assert.equal(pkg.dsh.client.platform, 'web')
   assert.deepEqual(pkg.files, [
@@ -724,6 +724,14 @@ test('completion reminders support manual close and bounded timeout choices', ()
   assert.deepEqual(
     { ...exports.__testing.normalizeNotifyConfig({ enabled: true, timeout: 17 }) },
     { enabled: true, timeout: 10 },
+  )
+  assert.deepEqual(
+    { ...exports.__testing.normalizeNotifyConfig({ enabled: true, autoCloseMs: null }) },
+    { enabled: true, timeout: 0 },
+  )
+  assert.deepEqual(
+    { ...exports.__testing.normalizeNotifyConfig({ enabled: false, autoCloseMs: 30000 }) },
+    { enabled: false, timeout: 30 },
   )
 
   const { Component } = walletComponent(exports)
@@ -1522,6 +1530,29 @@ test('host settings section renders the restyled card without crashing', () => {
   assert.ok(reminderCard, 'reminder and session controls must stay grouped')
 })
 
+test('client selects the balance row matching the server-selected currency', () => {
+  const renderer = createHookRenderer()
+  const { exports } = loadClientBundle(renderer.React)
+  const rows = [
+    { currency: 'USD', total_balance: '9.00' },
+    { currency: 'CNY', total_balance: '2.00' },
+  ]
+  assert.equal(exports.__testing.selectBalanceInfo({ currency: 'CNY', balances: rows }), rows[1])
+  assert.equal(exports.__testing.selectBalanceInfo({ currency: 'USD', balances: rows }), rows[0])
+  assert.equal(exports.__testing.selectBalanceInfo({ currency: 'EUR', balances: rows }), rows[0])
+  assert.equal(exports.__testing.selectBalanceInfo({ currency: 'CNY', balances: [] }), null)
+  assert.equal(exports.__testing.balanceErrorText('unauthorized'), 'API Key 无效或已过期')
+  assert.equal(exports.__testing.balanceErrorText('a raw upstream secret'), '余额暂不可用')
+})
+
+test('settings account API Key field is masked as a password input', () => {
+  const renderer = createHookRenderer()
+  const { exports } = loadClientBundle(renderer.React)
+  const tree = renderer.render(exports.__testing.WalletSettingsSection, { close: () => {} })
+  const keyInput = findElement(tree, element => element.type === 'input' && element.props['aria-label'] === 'API Key')
+  assert.ok(keyInput)
+  assert.equal(keyInput.props.type, 'password')
+})
 test('session cost follows the active account currency with a marked estimate', () => {
   const source = readProjectFile('lib/client.js')
   assert.match(source, /function sessionCostText/, 'a currency-aware session cost helper must exist')
@@ -1563,6 +1594,140 @@ test('settings section renders populated data from the wallet APIs', async () =>
   assert.ok(/1.98/.test(text), 'the balance figure must render')
 })
 
+function installWalletRouteHarness(mod, credentials) {
+  const routes = new Map()
+  let usageTap = null
+  const ctx = {
+    logger: { warn() {} },
+    get(key) { return key === 'credentials' ? credentials : undefined },
+    on(name, handler) { if (name === 'llm/stream') usageTap = handler },
+    effect(run) { return run() },
+    webServer: {
+      register(definition) {
+        routes.set(definition.path, definition.handler)
+        return () => routes.delete(definition.path)
+      },
+    },
+  }
+  mod.apply(ctx, {})
+  async function call(path, method, body, url = path) {
+    const handler = routes.get(path)
+    assert.equal(typeof handler, 'function', `missing route ${path}`)
+    const req = createRouteRequest(method, body, url)
+    const handled = Promise.resolve(handler(req, req.response))
+    const response = await req.send()
+    await handled
+    return { ...response, json: JSON.parse(response.body) }
+  }
+  return { call, usageTap }
+}
+
+test('provider aliases are actually billed in the official bucket after opt-in', async () => {
+  const previousHome = process.env.DSH_HOME
+  const dir = mkdtempSync(join(tmpdir(), 'dshw-provider-route-'))
+  process.env.DSH_HOME = dir
+  const mod = await import('../index.js?provider-route-' + dir.replace(/[\\/]/g, '_'))
+  try {
+    const harness = installWalletRouteHarness(mod, undefined)
+    let response = await harness.call('/api/wallet/official-providers', 'POST', { providers: ['deepseek-vision'] })
+    assert.deepEqual(response.json.official, ['deepseek-vision'])
+    assert.equal(typeof harness.usageTap, 'function')
+    const downstream = async function* () {
+      yield { type: 'usage', usage: { inputTokens: 1000, outputTokens: 2000 } }
+    }
+    for await (const _ of harness.usageTap(
+      { sessionId: 'session-provider-route', provider: 'deepseek-vision', model: 'deepseek-v4-flash' },
+      () => downstream(),
+    )) {}
+    response = await harness.call(
+      '/api/wallet/snapshot',
+      'GET',
+      undefined,
+      '/api/wallet/snapshot?session=session-provider-route',
+    )
+    assert.equal(response.json.session.official.tokens.input, 1000)
+    assert.equal(response.json.session.official.tokens.output, 2000)
+    assert.ok(response.json.session.official.cost > 0)
+    assert.equal(response.json.session.third.tokens.input, 0)
+    assert.deepEqual(response.json.providers.known, [])
+  } finally {
+    process.env.DSH_HOME = previousHome
+    await new Promise(resolve => setTimeout(resolve, 550))
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('first account rolls back activeId when the host refuses credential synchronization', async () => {
+  const previousHome = process.env.DSH_HOME
+  const dir = mkdtempSync(join(tmpdir(), 'dshw-account-rollback-'))
+  process.env.DSH_HOME = dir
+  const mod = await import('../index.js?account-rollback-' + dir.replace(/[\\/]/g, '_'))
+  try {
+    const harness = installWalletRouteHarness(mod, {
+      async set() { throw new Error('shadowed write refused') },
+      async resolve() { return undefined },
+    })
+    const response = await harness.call('/api/wallet/accounts', 'POST', {
+      name: '未同步账户', apiKey: 'sk-unsynced-1234567890',
+    })
+    assert.equal(response.json.ok, true)
+    assert.equal(response.json.synced, false)
+    assert.equal(response.json.account.active, false)
+    assert.equal((await harness.call('/api/wallet/accounts', 'GET')).json.activeId, null)
+  } finally {
+    process.env.DSH_HOME = previousHome
+    await new Promise(resolve => setTimeout(resolve, 550))
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('removing an account persists removal of its account-specific threshold', async () => {
+  const previousHome = process.env.DSH_HOME
+  const dir = mkdtempSync(join(tmpdir(), 'dshw-threshold-remove-'))
+  process.env.DSH_HOME = dir
+  const mod = await import('../index.js?threshold-remove-' + dir.replace(/[\\/]/g, '_'))
+  try {
+    const harness = installWalletRouteHarness(mod, {
+      async set() {},
+      async resolve() { return undefined },
+    })
+    const account = mod.addAccount('阈值账户', 'sk-threshold-1234567890').account
+    await harness.call('/api/wallet/threshold', 'POST', { threshold: 4.25, currency: 'CNY' })
+    await harness.call('/api/wallet/accounts/remove', 'POST', { id: account.id })
+    await new Promise(resolve => setTimeout(resolve, 650))
+    const wallet = JSON.parse(readFileSync(join(dir, 'storages', 'wallet.json'), 'utf8'))
+    assert.equal(Object.hasOwn(wallet.accountThresholds || {}, account.id), false)
+  } finally {
+    process.env.DSH_HOME = previousHome
+    await new Promise(resolve => setTimeout(resolve, 100))
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('balance refresh returns safe error enums instead of upstream error text', async () => {
+  const previousHome = process.env.DSH_HOME
+  const previousFetch = globalThis.fetch
+  const dir = mkdtempSync(join(tmpdir(), 'dshw-safe-error-'))
+  process.env.DSH_HOME = dir
+  const mod = await import('../index.js?safe-error-' + dir.replace(/[\\/]/g, '_'))
+  globalThis.fetch = async () => ({ ok: false, status: 401, async json() { return {} } })
+  try {
+    const harness = installWalletRouteHarness(mod, {
+      async set() {},
+      async resolve() { return { value: 'sk-safe-error-1234567890' } },
+    })
+    const response = await harness.call('/api/wallet/refresh', 'POST')
+    assert.equal(response.json.ok, true)
+    const snapshot = await harness.call('/api/wallet/snapshot', 'GET')
+    assert.equal(snapshot.json.balance.error, 'unauthorized')
+    assert.doesNotMatch(JSON.stringify(snapshot.json), /sk-safe-error|status 401/)
+  } finally {
+    globalThis.fetch = previousFetch
+    process.env.DSH_HOME = previousHome
+    await new Promise(resolve => setTimeout(resolve, 100))
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
 test('provider aliasing: wrapper routes can join the official bucket (Issue #21)', async () => {
   const { isOfficialProvider, normalizeProviderList, normalizeStoreData } = await import('../index.js')
   assert.equal(isOfficialProvider('deepseek-official'), true)


### PR DESCRIPTION
## 中文

发布 `deepseek-harness-wallet` v0.2.3。

### 主要修复

- 修复 Provider 分桶勾选后仍进入第三方桶的问题；包装 Provider 现在真正参与官方计费。
- 记录新观察到的 Provider，设置页可以继续进行官方/第三方归类。
- 修复首次添加账户时凭证同步失败仍显示为当前账户的问题。
- 修复删除账户后账户专属阈值没有持久化清理的问题。
- 修复多币种余额记录顺序导致的余额明细错配。
- 将余额错误改为安全枚举，避免上游错误原文进入浏览器。
- 统一提醒配置存储格式，并兼容旧版 `autoCloseMs` 数据。
- API Key 输入框默认隐藏。
- 更新中英文 README、CHANGELOG 和版本号至 `0.2.3`。

### 验证

- 插件回归测试：70/70 通过
- 语法检查：通过
- 发布包清单检查：通过
- 宿主定向测试：49/49 通过
- 宿主完整构建：通过
- 本地 Harness 部署与 API/界面验证：通过
- GitHub 账户 2FA：已开启

## English

Release `deepseek-harness-wallet` v0.2.3.

### Highlights

- Fixed provider classification so opted-in wrapper providers are actually billed in the official bucket.
- Newly observed providers are recorded and can be classified from settings.
- Fixed first-account activation rollback when credential synchronization is refused.
- Persisted removal of account-specific thresholds when an account is deleted.
- Aligned multi-currency balance detail selection with the server-selected currency.
- Replaced raw upstream balance errors with safe browser-facing error enums.
- Unified reminder configuration storage and migrated the legacy `autoCloseMs` shape.
- API-key inputs are now password fields by default.
- Updated bilingual README, CHANGELOG, and package version to `0.2.3`.

### Verification

- Plugin regression tests: 70/70 passed
- Syntax checks: passed
- Publishable package check: passed
- Host focused tests: 49/49 passed
- Host full build: passed
- Local Harness deployment and API/UI verification: passed
- GitHub account 2FA: enabled
