### PR TITLE
release: v0.2.5 peak card bounds and theme hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project are documented in this file.
 
+## 0.2.5 - 2026-08-23
+
+- 修复浮动峰谷卡片在窗口缩放、卡片放大或历史坐标过期后可能跑出视口的问题；加载、缩放、排版切换和 resize 都会重新钳制位置。 / Fixed floating peak cards escaping the viewport after resize, scale changes, or stale saved coordinates; load, scale, layout changes, and resize now re-clamp the position.
+- 恢复 Portal 挂载，确保自由浮动卡片和控制面板脱离侧边栏溢出裁剪。 / Restored Portal mounting so floating cards and the control panel escape sidebar overflow clipping.
+- 完成主题回退清理，移除峰谷控制面板、浮动卡片和开关中的硬编码浅色背景/文字回退。 / Completed theme fallback cleanup for the peak panel, floating card, and switches.
+- 保留账户安全、存储权限、刷新异常和偏好同步加固，并避免原始凭证错误文本进入日志或浏览器。 / Kept account-safety, storage-permission, refresh-failure, and preference-sync hardening without exposing raw credential errors to logs or the browser.
+- 新增浮动坐标边界、Portal 和完整主题回退回归测试；当前测试基线为 78/78。 / Added regression coverage for floating-coordinate bounds, Portal mounting, and complete theme fallbacks; the test baseline is now 78/78.
+
 ## 0.2.4 - 2026-08-22
 
 - 彻底修复暗色模式（Dark Mode）主题适配（Issue #26）：移除所有未主题化的浅色硬编码回退（`--dsw-alias-bg-elevated,#fff`、`--dsw-alias-bg-overlay,#fff` 等），全站统一使用 DSH 原生主题变量（`--dsw-alias-bg-layer-*` 与 `--dsw-alias-label-dimmed`），在深色模式下完美融入背景。 / Fully fixed Dark Mode theme compliance (Issue #26): replaced unthemed hardcoded light fallbacks with DSH native theme variables (`--dsw-alias-bg-layer-*`), rendering dark themes seamlessly without blinding white boxes.

--- a/RELEASE-NOTES-v0.2.5.md
+++ b/RELEASE-NOTES-v0.2.5.md
@@ -1,0 +1,29 @@
+## 中文
+
+**v0.2.5 是一次峰谷浮动卡片边界与主题兼容性修复。**
+
+- **浮动位置更可靠**：历史坐标、窗口缩放、卡片放大、横纵排版切换后都会重新限制在视口内，避免卡片跑出屏幕。
+- **恢复 Portal 挂载**：浮动卡片和专属控制面板继续脱离侧边栏溢出裁剪，保证自由拖动真正可用。
+- **暗色主题回退清理**：移除峰谷面板、浮动卡片、开关和按钮中的硬编码浅色背景/文字回退。
+- **保留安全加固**：账户错误枚举、存储权限、余额刷新异常处理、偏好同步防回声和拖拽点击隔离均保留。
+- **测试增强**：新增浮动坐标边界、Portal 和完整主题回退测试，当前 78/78 通过。
+
+**升级**：`dsh plugin --profile web update deepseek-harness-wallet`，重启 `dsh web` 后强制刷新页面。
+
+**兼容**：已在 DeepSeek Harness `0.1.0-rc.8`、Windows + Edge 实测；CI 覆盖 Ubuntu/macOS/Windows × Node 22.19/24。
+
+---
+
+## English
+
+**v0.2.5 is a reliability release for floating peak-clock bounds and theme compatibility.**
+
+- **Reliable floating bounds** — saved coordinates are re-clamped after load, viewport resize, scale changes, and orientation changes so the card stays reachable.
+- **Portal mounting restored** — floating cards and the dedicated control panel escape sidebar overflow clipping, keeping free dragging reliable.
+- **Dark-theme fallback cleanup** — removed hardcoded light background/text fallbacks from the peak panel, floating card, switches, and buttons.
+- **Security hardening retained** — bounded account errors, storage permissions, balance-refresh failure handling, preference self-echo protection, and drag/click isolation remain covered.
+- **Stronger tests** — added floating-coordinate, Portal, and complete theme-fallback regression coverage; 78/78 tests pass.
+
+**Upgrade**: `dsh plugin --profile web update deepseek-harness-wallet`, restart `dsh web`, then hard-refresh the page.
+
+**Compatibility**: verified with DeepSeek Harness `0.1.0-rc.8` on Windows + Edge; CI covers Ubuntu/macOS/Windows × Node 22.19/24.

--- a/index.js
+++ b/index.js
@@ -78,7 +78,9 @@ export const PRICE_POLICIES = [
 export function ratesFor(model, atMs) {
   let entry
   for (const policy of PRICE_POLICIES) {
-    if (atMs >= policy.since && policy.models[model] !== undefined) entry = policy
+    // Own-property check: a model named `__proto__`/`toString` would otherwise
+    // resolve to an Object.prototype member and produce NaN costs.
+    if (atMs >= policy.since && Object.hasOwn(policy.models, model)) entry = policy
   }
   if (entry === undefined) return null
   const rates = entry.models[model]
@@ -258,9 +260,10 @@ function persistStore(logger) {
     saveTimer = null
   }
   try {
-    mkdirSync(dirname(STORE_PATH), { recursive: true })
+    mkdirSync(dirname(STORE_PATH), { recursive: true, mode: 0o700 })
     const tmp = STORE_PATH + '.tmp'
-    writeFileSync(tmp, JSON.stringify(store))
+    // Owner-only: the store carries usage accounting next to credential files.
+    writeFileSync(tmp, JSON.stringify(store), { mode: 0o600 })
     renameSync(tmp, STORE_PATH)
   } catch (error) {
     if (logger && typeof logger.warn === 'function') {
@@ -325,9 +328,10 @@ function persistAccounts(logger) {
     accountsSaveTimer = null
   }
   try {
-    mkdirSync(dirname(ACCOUNTS_PATH), { recursive: true })
+    mkdirSync(dirname(ACCOUNTS_PATH), { recursive: true, mode: 0o700 })
     const tmp = ACCOUNTS_PATH + '.tmp'
-    writeFileSync(tmp, JSON.stringify(accounts))
+    // This file holds plaintext API keys: owner-only, never group/world readable.
+    writeFileSync(tmp, JSON.stringify(accounts), { mode: 0o600 })
     renameSync(tmp, ACCOUNTS_PATH)
   } catch (error) {
     if (logger && typeof logger.warn === 'function') {
@@ -436,15 +440,20 @@ async function resolveBalanceKey(ctx) {
  */
 export async function activateAccount(ctx, id) {
   const account = findAccount(id)
-  if (account === null) return { ok: false, error: 'account not found' }
+  if (account === null) return { ok: false, error: 'account-not-found' }
   const credentials = ctx.get('credentials')
-  if (credentials === undefined) return { ok: false, error: 'credentials service unavailable' }
+  if (credentials === undefined) return { ok: false, error: 'credentials-unavailable' }
   try {
     await credentials.set(CREDENTIAL_REF, account.apiKey)
   } catch (error) {
     // e.g. the launching environment supplies DEEPSEEK_API_KEY read-only, so
-    // the write is shadowed and refused by the credentials provider.
-    return { ok: false, error: error instanceof Error ? error.message : String(error) }
+    // the write is shadowed and refused by the credentials provider. Keep the
+    // browser error bounded and do not log provider text that might contain
+    // paths, environment details, or key fragments.
+    if (ctx.logger && typeof ctx.logger.warn === 'function') {
+      ctx.logger.warn('dsh-wallet: credential write refused')
+    }
+    return { ok: false, error: 'credential-write-refused' }
   }
   accounts.activeId = account.id
   scheduleAccountsSave(ctx.logger)
@@ -509,12 +518,12 @@ let balance = { fetchedAt: 0, available: false, balances: [], error: null }
 let balanceRefresh = null
 
 async function performBalanceRefresh(ctx) {
-  const credentials = ctx.get('credentials')
-  if (credentials === undefined) {
-    balance = { fetchedAt: Date.now(), available: false, balances: [], error: 'no-credentials' }
-    return
-  }
   try {
+    const credentials = ctx.get('credentials')
+    if (credentials === undefined) {
+      balance = { fetchedAt: Date.now(), available: false, balances: [], error: 'no-credentials' }
+      return
+    }
     const key = await resolveBalanceKey(ctx)
     if (key === undefined || key === '') {
       balance = { fetchedAt: Date.now(), available: false, balances: [], error: 'no-api-key' }
@@ -564,9 +573,24 @@ async function performBalanceRefresh(ctx) {
 
 function refreshBalance(ctx) {
   if (balanceRefresh !== null) return balanceRefresh
-  balanceRefresh = performBalanceRefresh(ctx).finally(() => {
-    balanceRefresh = null
-  })
+  // Never let a refresh escape as an unhandled rejection: every caller uses
+  // `void refreshBalance(ctx)`, so a throw here would take the host process
+  // down (Node exits on unhandled rejections). Absorb it into the error state.
+  balanceRefresh = performBalanceRefresh(ctx)
+    .catch((error) => {
+      balance = {
+        fetchedAt: Date.now(),
+        available: false,
+        balances: [],
+        error: 'balance-unavailable',
+      }
+      if (ctx && ctx.logger && typeof ctx.logger.warn === 'function') {
+        ctx.logger.warn('dsh-wallet: balance refresh failed')
+      }
+    })
+    .finally(() => {
+      balanceRefresh = null
+    })
   return balanceRefresh
 }
 
@@ -609,8 +633,18 @@ function balanceTotal() {
 
 function sessionView(sessionId) {
   if (sessionId === undefined || sessionId === '') return { official: null, third: null }
+  // Own-property lookup only: session ids like `__proto__`, `constructor` or
+  // `toString` otherwise resolve to an Object.prototype member, slip past the
+  // undefined guard, and throw inside bucketTotals.
+  if (!Object.prototype.hasOwnProperty.call(store.sessions, sessionId)) {
+    return { official: null, third: null }
+  }
   const session = store.sessions[sessionId]
-  if (session === undefined) return { official: null, third: null }
+  if (session === null || typeof session !== 'object'
+    || session.official === null || typeof session.official !== 'object'
+    || session.third === null || typeof session.third !== 'object') {
+    return { official: null, third: null }
+  }
   const official = bucketTotals(session.official)
   const third = bucketTotals(session.third)
   return {

--- a/lib/client.js
+++ b/lib/client.js
@@ -23,7 +23,7 @@ window.__ModuleLoader__.load({
 
     var POLL_MS = 15000
     // Keep in lockstep with package.json; a test enforces the sync.
-    var WALLET_VERSION = '0.2.4'
+    var WALLET_VERSION = '0.2.5'
     var CONFIRM_KEY = 'dsh-wallet-recharge-confirmed'
     var CHIP_LAYOUT_KEY = 'dshw-chip-layout-v4'
     var PANEL_POS_KEY = 'dshw-panel-pos-v1'
@@ -62,11 +62,18 @@ window.__ModuleLoader__.load({
         ? root.__DSH_WALLET_ADAPTER__
         : {}
       var memory = Object.create(null)
+      // Keys whose native write was refused (quota, private mode, sandboxed
+      // WebView). Reads for those keys must come from memory, otherwise the
+      // fallback write is invisible and the UI keeps reading a stale value.
+      var memoryOnly = Object.create(null)
       var nativeStorage = extension.storage || root.localStorage || null
       var pageNotices = new Map()
 
       var storage = {
         getItem: function (key) {
+          if (memoryOnly[key] === true) {
+            return Object.prototype.hasOwnProperty.call(memory, key) ? memory[key] : null
+          }
           if (nativeStorage && typeof nativeStorage.getItem === 'function') {
             try { return nativeStorage.getItem(key) } catch (e) { /* storage may be disabled */ }
           }
@@ -76,13 +83,19 @@ window.__ModuleLoader__.load({
           value = String(value)
           memory[key] = value
           if (nativeStorage && typeof nativeStorage.setItem === 'function') {
-            try { nativeStorage.setItem(key, value); return } catch (e) { /* use memory below */ }
+            try {
+              nativeStorage.setItem(key, value)
+              delete memoryOnly[key]
+              return
+            } catch (e) { /* fall through to the memory-only marker */ }
           }
+          memoryOnly[key] = true
         },
         removeItem: function (key) {
           delete memory[key]
+          delete memoryOnly[key]
           if (nativeStorage && typeof nativeStorage.removeItem === 'function') {
-            try { nativeStorage.removeItem(key); return } catch (e) { /* use memory below */ }
+            try { nativeStorage.removeItem(key); return } catch (e) { /* memory copy is already gone */ }
           }
         }
       }
@@ -277,7 +290,7 @@ window.__ModuleLoader__.load({
       '.dshw_anchorHome{overflow:hidden;min-width:44px}',
       '.dshw_chipLift{z-index:80!important}',
       '.dshw_anchorHome>.dshw_chip{box-sizing:border-box;max-width:100%;min-width:0;overflow:hidden}',
-      '.dshw_chip{border:1px solid var(--dsw-alias-border-l2,rgba(127,127,127,.25));background:transparent;height:22px;color:var(--dsw-alias-label-primary,#1f2328);white-space:nowrap;border-radius:999px;align-items:stretch;font-size:12px;line-height:1;display:inline-flex;position:relative;touch-action:none;user-select:none;cursor:grab}',
+      '.dshw_chip{border:1px solid var(--dsw-alias-border-l2,rgba(127,127,127,.25));background:transparent;height:22px;color:var(--dsw-alias-label-primary,inherit);white-space:nowrap;border-radius:999px;align-items:stretch;font-size:12px;line-height:1;display:inline-flex;position:relative;touch-action:none;user-select:none;cursor:grab}',
       '.dshw_chip:hover,.dshw_chip:focus-within{border-color:var(--dsw-alias-brand-primary,#4aa3ff)}',
       '.dshw_chipLow{border-color:var(--dsw-alias-state-error-primary,#e5534b);color:var(--dsw-alias-state-error-primary,#e5534b);animation:dshwChipPulseIn 1.8s ease-in-out infinite}',
       '.dshw_chipLow:hover,.dshw_chipLow:focus-within{border-color:var(--dsw-alias-state-error-primary,#e5534b)}',
@@ -302,7 +315,7 @@ window.__ModuleLoader__.load({
       '.dshw_chipVertical.dshw_chipNoRecharge .dshw_chipMain{border-radius:7px}',
       '.dshw_recharge{color:var(--dsw-alias-brand-primary,#4aa3ff);border-left:1px solid var(--dsw-alias-border-l2,rgba(127,127,127,.25));padding:0 7px 0 6px;border-radius:0 999px 999px 0}',
       '.dshw_chipMain:focus-visible,.dshw_recharge:focus-visible,.dshw_btn:focus-visible,.dshw_floatBtn:focus-visible,.dshw_dot:focus-visible{outline:2px solid var(--dsw-alias-brand-primary,#4aa3ff);outline-offset:2px}',
-      '.dshw_panel{z-index:40;border:1px solid var(--dsw-alias-border-l2,rgba(127,127,127,.25));background:var(--dsw-alias-bg-layer-2,var(--dsw-alias-bg-layer-1,#21262d));box-sizing:border-box;width:min(276px,calc(100vw - 12px));max-height:calc(100vh - 16px);overflow:auto;color:var(--dsw-alias-label-primary,#1f2328);border-radius:8px;flex-direction:column;gap:4px;padding:8px 9px;font-size:12px;display:flex;position:fixed;box-shadow:0 4px 16px rgba(0,0,0,.35)}',
+      '.dshw_panel{z-index:40;border:1px solid var(--dsw-alias-border-l2,rgba(127,127,127,.25));background:var(--dsw-alias-bg-layer-2,var(--dsw-alias-bg-layer-1,var(--dsw-alias-bg-base,transparent)));box-sizing:border-box;width:min(276px,calc(100vw - 12px));max-height:calc(100vh - 16px);overflow:auto;color:var(--dsw-alias-label-primary,inherit);border-radius:8px;flex-direction:column;gap:4px;padding:8px 9px;font-size:12px;display:flex;position:fixed;box-shadow:0 4px 16px rgba(0,0,0,.35)}',
       '.dshw_panelHeader{min-height:24px;cursor:move;touch-action:none;user-select:none}',
       '.dshw_panelHeader .dshw_btn{cursor:pointer}',
       '.dshw_row{justify-content:space-between;align-items:center;gap:6px;display:flex}',
@@ -319,7 +332,7 @@ window.__ModuleLoader__.load({
       '.dshw_check input{margin:0;accent-color:var(--dsw-alias-brand-primary,#4aa3ff)}',
       '.dshw_select{background:var(--dsw-alias-bg-layer-1,var(--dsw-alias-bg-base,rgba(127,127,127,.08)));border:1px solid var(--dsw-alias-border-l2,rgba(127,127,127,.25));color:var(--dsw-alias-label-primary,inherit);border-radius:5px;padding:2px 4px;font-size:12px}',
       '.dshw_btn{border:1px solid var(--dsw-alias-border-l2,rgba(127,127,127,.25));background:var(--dsw-alias-bg-layer-1,transparent);color:var(--dsw-alias-label-primary,inherit);border-radius:5px;padding:2px 6px;font-size:12px;cursor:pointer}',
-      '.dshw_btnPrimary{background:var(--dsw-alias-brand-primary,#4aa3ff);border-color:transparent;color:var(--dsw-alias-label-primary-foreground,#ffffff)}',
+      '.dshw_btnPrimary{background:var(--dsw-alias-brand-primary,#4aa3ff);border-color:transparent;color:var(--dsw-alias-label-primary-foreground,var(--dsw-alias-label-primary,inherit))}',
       // ---- v0.2 panel restyle: balance card, settings card, account scroll ----
       '.dshw_balanceCard{margin:2px 0 2px;padding:8px 10px;border:1px solid var(--dsw-alias-border-l2,rgba(127,127,127,.2));border-radius:8px;background:var(--dsw-alias-bg-layer-1,var(--dsw-alias-bg-base,rgba(127,127,127,.06)))}',
       '.dshw_balLine{display:flex;align-items:center;gap:7px;white-space:nowrap}',
@@ -411,7 +424,7 @@ window.__ModuleLoader__.load({
       '.dshw_switch{position:relative;flex:none;width:34px;height:20px;display:inline-flex;cursor:pointer}',
       '.dshw_switch>input{position:absolute;inset:0;opacity:0;margin:0;cursor:pointer}',
       '.dshw_track{position:absolute;inset:0;border-radius:999px;background:var(--dsw-alias-border-l3,rgba(127,127,127,.3));transition:background-color .15s}',
-      '.dshw_knob{position:absolute;left:2px;top:2px;width:16px;height:16px;border-radius:50%;background:var(--dsw-alias-bg-layer-1,#fff);box-shadow:0 1px 3px rgba(0,0,0,.24);transition:transform .15s}',
+      '.dshw_knob{position:absolute;left:2px;top:2px;width:16px;height:16px;border-radius:50%;background:var(--dsw-alias-bg-layer-1,var(--dsw-alias-bg-base,transparent));box-shadow:0 1px 3px rgba(0,0,0,.24);transition:transform .15s}',
       '.dshw_switch>input:checked+.dshw_track{background:var(--dsw-alias-brand-primary,#4aa3ff)}',
       '.dshw_switch>input:checked~.dshw_knob{transform:translateX(14px)}',
       '.dshw_switch>input:focus-visible+.dshw_track{outline:2px solid var(--dsw-alias-brand-primary,#4aa3ff);outline-offset:2px}',
@@ -442,7 +455,7 @@ window.__ModuleLoader__.load({
       '.dshw_footRingVertical .dshw_footRingCountdown{font-size:10.5px;overflow:visible;white-space:nowrap}',
       '.dshw_footRingVertical .dshw_footRingBottom{justify-content:center}',
       '.dshw_footRingNoRecharge{padding-right:10px}',
-      '.dshw_footRingFloating{position:fixed;z-index:90;width:auto;min-width:180px;max-width:260px;margin:0!important;border:1px solid var(--dsw-alias-border-l2,rgba(127,127,127,.25));background:var(--dsw-alias-bg-layer-2,var(--dsw-alias-bg-layer-1,#21262d));box-shadow:0 8px 24px rgba(0,0,0,.35);cursor:grab;touch-action:none}',
+      '.dshw_footRingFloating{position:fixed;z-index:90;width:auto;min-width:180px;max-width:260px;margin:0!important;border:1px solid var(--dsw-alias-border-l2,rgba(127,127,127,.25));background:var(--dsw-alias-bg-layer-2,var(--dsw-alias-bg-layer-1,var(--dsw-alias-bg-base,transparent)));box-shadow:0 8px 24px rgba(0,0,0,.35);cursor:grab;touch-action:none}',
       '.dshw_footRingFloating.dshw_footRingVertical{min-width:132px;max-width:152px;width:140px;padding:9px 8px;gap:4px}',
       '.dshw_footRingFloating.dshw_footRingVertical .dshw_footRingResetBtn{position:absolute;top:4px;right:4px;font-size:9.5px;padding:1px 5px;line-height:13px}',
       '.dshw_footRingFloating.dshw_footRingDragging{cursor:grabbing;box-shadow:0 10px 30px rgba(0,0,0,.45)}',
@@ -459,8 +472,8 @@ window.__ModuleLoader__.load({
       '.dshw_footRingBottom{display:flex;align-items:center;justify-content:space-between;gap:6px;width:100%;min-height:18px}',
       '.dshw_footRingCountdown{font-size:11px;color:var(--dsw-alias-label-secondary,rgba(127,127,127,.85));line-height:1.2;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;flex:1 1 auto;min-width:0}',
       '.dshw_footRingBtnRechargeInline{border:1px solid var(--dsw-alias-brand-primary,#4aa3ff);background:var(--dsw-alias-brand-soft,rgba(74,163,255,.10));color:var(--dsw-alias-brand-primary,#4aa3ff);border-radius:4px;height:18px;padding:0 6px;font-size:10.5px;font-weight:600;line-height:16px;cursor:pointer;display:inline-flex;align-items:center;justify-content:center;transition:all .15s ease;user-select:none;flex:none}',
-      '.dshw_footRingBtnRechargeInline:hover{background:var(--dsw-alias-brand-primary,#4aa3ff);color:#fff}',
-      '.dshw_peakPanel{position:fixed;z-index:95;width:290px;box-sizing:border-box;border:1px solid var(--dsw-alias-border-l2,rgba(127,127,127,.25));background:var(--dsw-alias-bg-layer-2,var(--dsw-alias-bg-layer-1,#21262d));color:var(--dsw-alias-label-primary,inherit);border-radius:12px;box-shadow:0 10px 32px rgba(0,0,0,.38);display:flex;flex-direction:column;gap:8px;padding:12px 14px;font-size:12px;user-select:none;touch-action:none}',
+      '.dshw_footRingBtnRechargeInline:hover{background:var(--dsw-alias-brand-primary,#4aa3ff);color:var(--dsw-alias-label-primary-foreground,var(--dsw-alias-label-primary,inherit))}',
+      '.dshw_peakPanel{position:fixed;z-index:95;width:290px;box-sizing:border-box;border:1px solid var(--dsw-alias-border-l2,rgba(127,127,127,.25));background:var(--dsw-alias-bg-layer-2,var(--dsw-alias-bg-layer-1,var(--dsw-alias-bg-base,transparent)));color:var(--dsw-alias-label-primary,inherit);border-radius:12px;box-shadow:0 10px 32px rgba(0,0,0,.38);display:flex;flex-direction:column;gap:8px;padding:12px 14px;font-size:12px;user-select:none;touch-action:none}',
       '.dshw_peakPanelHeader{display:flex;align-items:center;justify-content:space-between;font-weight:650;font-size:12.5px;color:var(--dsw-alias-label-primary,inherit)}',
       '.dshw_peakPanelClose{border:none;background:transparent;color:inherit;font-size:16px;line-height:1;cursor:pointer;padding:2px 6px;border-radius:4px}',
       '.dshw_peakPanelClose:hover{background:var(--dsw-alias-interactive-bg-hover,rgba(127,127,127,.12))}',
@@ -471,23 +484,23 @@ window.__ModuleLoader__.load({
       '.dshw_ringNeutral{stroke:var(--dsw-alias-border-l3,rgba(127,127,127,.3))}',
       '.dshw_peakRing circle{transition:stroke-width .3s ease}',
       '.dshw_ringNow{stroke-width:6;filter:brightness(1.15)}',
-      '.dshw_ringPointer{fill:var(--dsw-alias-label-primary,#1f2328)}',
+      '.dshw_ringPointer{fill:var(--dsw-alias-label-primary,inherit)}',
       '.dshw_ringTick{fill:var(--dsw-alias-label-dimmed,var(--dsw-alias-label-tertiary,#8b949e))}',
       '@media (max-width:760px){.dshw_settingsGrid,.dshw_settingsSection .dshw_setCard{grid-template-columns:1fr}.dshw_settingsSection .dshw_setCard>.dshw_setCell.wide{grid-column:1}.dshw_accountAdd{grid-template-columns:1fr}.dshw_settingsFooter{align-items:flex-start;flex-direction:column-reverse}.dshw_settingsFooterActions{width:100%}.dshw_settingsFooterActions .dshw_btn{flex:1}.dshw_settingsHeroMeta{white-space:normal;flex-wrap:wrap}}',
       '.dshw_actionRow{display:grid;grid-template-columns:1fr 1fr;gap:6px;margin:2px 0}',
       '.dshw_textDanger{display:inline-flex;align-items:center;gap:5px;height:22px;padding:0 4px;border:none;background:transparent;font:inherit;font-size:11px;color:var(--dsw-alias-label-dimmed,var(--dsw-alias-label-tertiary,#8b949e));cursor:pointer;border-radius:4px;transition:color .12s,background-color .12s}',
       '.dshw_textDanger:hover{color:var(--dsw-alias-state-error-primary,#e5534b);background:var(--dsw-alias-state-error-soft,rgba(229,83,75,.12))}',
       '.dshw_overlay{position:fixed;inset:0;background:var(--dsw-alias-bg-mask-drop,rgba(0,0,0,.55));display:flex;align-items:center;justify-content:center;z-index:100}',
-      '.dshw_overlayBox{background:var(--dsw-alias-bg-layer-2,var(--dsw-alias-bg-layer-1,#21262d));border:1px solid var(--dsw-alias-border-l2,rgba(127,127,127,.25));color:var(--dsw-alias-label-primary,#1f2328);border-radius:8px;padding:14px 18px;width:min(320px,calc(100vw - 32px));box-sizing:border-box;font-size:13px;line-height:1.7}',
+      '.dshw_overlayBox{background:var(--dsw-alias-bg-layer-2,var(--dsw-alias-bg-layer-1,var(--dsw-alias-bg-base,transparent)));border:1px solid var(--dsw-alias-border-l2,rgba(127,127,127,.25));color:var(--dsw-alias-label-primary,inherit);border-radius:8px;padding:14px 18px;width:min(320px,calc(100vw - 32px));box-sizing:border-box;font-size:13px;line-height:1.7}',
       '.dshw_overlayRow{margin-top:10px;display:flex;gap:8px;justify-content:flex-end}',
-      '.dshw_float{position:fixed;z-index:80;min-width:230px;max-width:280px;border:1px solid var(--dsw-alias-border-l2,rgba(127,127,127,.25));background:var(--dsw-alias-bg-layer-2,var(--dsw-alias-bg-layer-1,#21262d));color:var(--dsw-alias-label-primary,#1f2328);border-radius:12px;box-shadow:0 6px 20px rgba(0,0,0,.25);display:flex;flex-direction:column;gap:6px;padding:10px 12px;font-size:12px;user-select:none}',
+      '.dshw_float{position:fixed;z-index:80;min-width:230px;max-width:280px;border:1px solid var(--dsw-alias-border-l2,rgba(127,127,127,.25));background:var(--dsw-alias-bg-layer-2,var(--dsw-alias-bg-layer-1,var(--dsw-alias-bg-base,transparent)));color:var(--dsw-alias-label-primary,inherit);border-radius:12px;box-shadow:0 6px 20px rgba(0,0,0,.25);display:flex;flex-direction:column;gap:6px;padding:10px 12px;font-size:12px;user-select:none}',
       '.dshw_floatHeader{display:flex;align-items:center;justify-content:space-between;cursor:move;font-weight:600;opacity:.9;touch-action:none}',
       '.dshw_floatBtn{border:1px solid var(--dsw-alias-border-l2,rgba(127,127,127,.25));background:transparent;color:inherit;border-radius:5px;width:22px;height:20px;font-size:12px;line-height:1;cursor:pointer;padding:0}',
       '.dshw_floatBtn:hover{background:var(--dsw-alias-interactive-bg-hover,rgba(127,127,127,.1))}',
-      '.dshw_dot{position:fixed;z-index:80;width:36px;height:36px;border-radius:50%;border:1px solid var(--dsw-alias-border-l2,rgba(127,127,127,.25));background:var(--dsw-alias-bg-layer-2,var(--dsw-alias-bg-layer-1,#21262d));color:var(--dsw-alias-label-primary,#1f2328);font-size:11px;display:flex;align-items:center;justify-content:center;cursor:pointer;box-shadow:0 2px 10px rgba(0,0,0,.25);user-select:none;touch-action:none}',
+      '.dshw_dot{position:fixed;z-index:80;width:36px;height:36px;border-radius:50%;border:1px solid var(--dsw-alias-border-l2,rgba(127,127,127,.25));background:var(--dsw-alias-bg-layer-2,var(--dsw-alias-bg-layer-1,var(--dsw-alias-bg-base,transparent)));color:var(--dsw-alias-label-primary,inherit);font-size:11px;display:flex;align-items:center;justify-content:center;cursor:pointer;box-shadow:0 2px 10px rgba(0,0,0,.25);user-select:none;touch-action:none}',
       '.dshw_dotLow{border-color:var(--dsw-alias-state-error-primary,#e5534b);color:var(--dsw-alias-state-error-primary,#e5534b)}',
       '.dshw_noticeStack{position:fixed;z-index:120;top:max(12px,env(safe-area-inset-top));right:max(12px,env(safe-area-inset-right));width:min(340px,calc(100vw - 24px));display:flex;flex-direction:column;gap:8px;pointer-events:none}',
-      '.dshw_notice{box-sizing:border-box;width:100%;display:flex;align-items:flex-start;gap:8px;padding:10px 10px 10px 12px;border:1px solid var(--dsw-alias-border-l2,rgba(127,127,127,.25));border-radius:9px;background:var(--dsw-alias-bg-layer-2,var(--dsw-alias-bg-layer-1,#21262d));color:var(--dsw-alias-label-primary,#1f2328);box-shadow:0 6px 20px rgba(0,0,0,.25);font-size:12px;line-height:1.45;pointer-events:auto;cursor:pointer}',
+      '.dshw_notice{box-sizing:border-box;width:100%;display:flex;align-items:flex-start;gap:8px;padding:10px 10px 10px 12px;border:1px solid var(--dsw-alias-border-l2,rgba(127,127,127,.25));border-radius:9px;background:var(--dsw-alias-bg-layer-2,var(--dsw-alias-bg-layer-1,var(--dsw-alias-bg-base,transparent)));color:var(--dsw-alias-label-primary,inherit);box-shadow:0 6px 20px rgba(0,0,0,.25);font-size:12px;line-height:1.45;pointer-events:auto;cursor:pointer}',
       '.dshw_noticeCopy{min-width:0;display:flex;flex:1;flex-direction:column;gap:2px}.dshw_noticeCopy span{white-space:pre-line;overflow-wrap:anywhere}',
       '.dshw_noticeClose{flex:none;width:24px;height:24px;border:0;border-radius:5px;background:transparent;color:inherit;font-size:18px;line-height:1;cursor:pointer}.dshw_noticeClose:hover{background:var(--dsw-alias-interactive-bg-hover,rgba(127,127,127,.1))}',
       // Home-fit and compact modes are toggled by measured space (see the
@@ -1085,6 +1098,26 @@ window.__ModuleLoader__.load({
       return (counters.input || 0) + (counters.output || 0) + (counters.cacheRead || 0) + (counters.cacheWrite || 0)
     }
 
+    // Keep the floating peak card reachable after a viewport resize, a
+    // persisted position from another screen size, or a scale change. `width`
+    // and `height` are the rendered dimensions from getBoundingClientRect(),
+    // so transformed 120% cards are clamped using their actual footprint.
+    function clampPeakPosition(pos, width, height, viewportWidth, viewportHeight, margin) {
+      margin = Number.isFinite(margin) ? Math.max(0, margin) : 8
+      viewportWidth = Number.isFinite(viewportWidth) ? viewportWidth : 1024
+      viewportHeight = Number.isFinite(viewportHeight) ? viewportHeight : 768
+      width = Number.isFinite(width) && width > 0 ? width : 180
+      height = Number.isFinite(height) && height > 0 ? height : 60
+      var x = pos && Number.isFinite(pos.x) ? pos.x : margin
+      var y = pos && Number.isFinite(pos.y) ? pos.y : margin
+      var maxX = Math.max(margin, viewportWidth - width - margin)
+      var maxY = Math.max(margin, viewportHeight - height - margin)
+      return {
+        x: Math.round(Math.min(maxX, Math.max(margin, x))),
+        y: Math.round(Math.min(maxY, Math.max(margin, y))),
+      }
+    }
+
     /**
      * Host settings-panel section: the same wallet controls as the chip panel,
      * as an independent card. Shares state with the chip through the same
@@ -1662,7 +1695,7 @@ window.__ModuleLoader__.load({
           type: 'button', className: 'dshw_btn dshw_btnPrimary',
           onClick: function () { if (close) close(); window.open('https://platform.deepseek.com/top_up', '_blank', 'noopener') }
         }, '↗ 去官方充值'))))
-      return React.createElement('div', { className: 'dshw_settingsSection', style: { display: 'flex', flexDirection: 'column', gap: '6px', fontSize: '12px', color: 'var(--dsw-alias-label-primary,#1f2328)' } }, rows)
+      return React.createElement('div', { className: 'dshw_settingsSection', style: { display: 'flex', flexDirection: 'column', gap: '6px', fontSize: '12px', color: 'var(--dsw-alias-label-primary,inherit)' } }, rows)
     }
 
     // Wall-clock hour (0-24, fractional) inside an IANA timezone, via Intl —
@@ -1809,6 +1842,12 @@ window.__ModuleLoader__.load({
       var [nowMs, setNowMs] = React.useState(function () { return Date.now() })
       var dragRef = React.useRef(null)
       var didDragRef = React.useRef(false)
+      // Guards the self-echo: every preference write dispatches the shared
+      // change events so OTHER surfaces resync, but this component must not
+      // re-read storage from its own dispatch — the listener would setState a
+      // second time from a different call stack and race the update already
+      // queued, which can drop the write that started it.
+      var suppressSelfSyncRef = React.useRef(false)
       var [panelOpen, setPanelOpen] = React.useState(false)
       var [panelPos, setPanelPos] = React.useState({ left: 16, top: 16 })
       var cardNodeRef = React.useRef(null)
@@ -1828,6 +1867,8 @@ window.__ModuleLoader__.load({
         loadSnap()
         var listensEvents = typeof window.addEventListener === 'function'
         function onRingChange() {
+          // Skip our own echo (see suppressSelfSyncRef).
+          if (suppressSelfSyncRef.current) return
           try {
             setShown(compatibility.storage.getItem(PEAK_RING_KEY) !== 'false')
             setOrient(compatibility.storage.getItem(PEAK_ORIENT_KEY) || 'horizontal')
@@ -1956,6 +1997,33 @@ window.__ModuleLoader__.load({
         } catch (e) { /* ignore */ }
       }, [policy, nowMs])
 
+      var isFreeFloating = dock === 'free'
+      var isVertical = orient === 'vertical' && (wide || isFreeFloating)
+      var isRail = !wide && !isFreeFloating
+
+      // A saved floating coordinate is not trustworthy after a window resize
+      // or scale change. Re-measure the rendered card (including transform)
+      // and persist the corrected coordinate before it can disappear outside
+      // the viewport. This hook must run even while the card is still loading,
+      // otherwise React sees a changing hook count when the snapshot arrives.
+      useLayoutEffect(function () {
+        if (!isFreeFloating || !cardNodeRef.current) return
+        var node = cardNodeRef.current
+        function fitFloatingPeakCard() {
+          if (!node || typeof node.getBoundingClientRect !== 'function') return
+          var rect = node.getBoundingClientRect()
+          var current = latestPosRef.current || pos || { x: rect.left, y: rect.top }
+          var fitted = clampPeakPosition(current, rect.width, rect.height, window.innerWidth, window.innerHeight, 8)
+          if (fitted.x === current.x && fitted.y === current.y && pos !== null) return
+          latestPosRef.current = fitted
+          setPos(fitted)
+          try { compatibility.storage.setItem(PEAK_POS_KEY, JSON.stringify(fitted)) } catch (e) { /* ignore */ }
+        }
+        fitFloatingPeakCard()
+        window.addEventListener('resize', fitFloatingPeakCard)
+        return function () { window.removeEventListener('resize', fitFloatingPeakCard) }
+      }, [isFreeFloating, pos, peakScale, orient, showRecharge])
+
       if (!shown || snapshot === undefined) return null
       var tzName = policy && policy.timezone ? policy.timezone : 'Asia/Shanghai'
       var offsetMinutes = policy && typeof policy.offsetMinutes === 'number' ? policy.offsetMinutes : 480
@@ -1971,33 +2039,41 @@ window.__ModuleLoader__.load({
       var costLabel = sessionCostLabel(balCurrency)
       var low = snapshot && snapshot.lowBalance === true
 
-      var isFreeFloating = dock === 'free'
-      var isVertical = orient === 'vertical' && (wide || isFreeFloating)
-      var isRail = !wide && !isFreeFloating
+      // Announce a preference change to the other surfaces (settings page, a
+      // second window) while suppressing our own listener, so this component's
+      // queued setState is the single writer for this interaction.
+      function announcePrefs(includeRingEvent) {
+        suppressSelfSyncRef.current = true
+        try {
+          try { compatibility.dispatch(SETTINGS_EVENT) } catch (e) { /* ignore */ }
+          if (includeRingEvent !== false) {
+            try { compatibility.dispatch(PEAK_RING_EVENT) } catch (e) { /* ignore */ }
+          }
+        } finally {
+          suppressSelfSyncRef.current = false
+        }
+      }
 
       function updateOrient(val) {
         setOrient(val)
         try { compatibility.storage.setItem(PEAK_ORIENT_KEY, val) } catch (e) { /* ignore */ }
-        try { compatibility.dispatch(SETTINGS_EVENT) } catch (e) { /* ignore */ }
-        try { compatibility.dispatch(PEAK_RING_EVENT) } catch (e) { /* ignore */ }
+        announcePrefs()
       }
       function updateScale(val) {
         val = Math.min(1.2, Math.max(1.0, Math.round(val * 20) / 20))
         setPeakScale(val)
         try { compatibility.storage.setItem(PEAK_SCALE_KEY, String(val)) } catch (e) { /* ignore */ }
-        try { compatibility.dispatch(SETTINGS_EVENT) } catch (e) { /* ignore */ }
-        try { compatibility.dispatch(PEAK_RING_EVENT) } catch (e) { /* ignore */ }
+        announcePrefs()
       }
       function updateRecharge(val) {
         setShowRecharge(val)
         try { compatibility.storage.setItem(PEAK_RECHARGE_KEY, String(val)) } catch (e) { /* ignore */ }
-        try { compatibility.dispatch(SETTINGS_EVENT) } catch (e) { /* ignore */ }
-        try { compatibility.dispatch(PEAK_RING_EVENT) } catch (e) { /* ignore */ }
+        announcePrefs()
       }
       function updateNotify(val) {
         setPeakNotify(val)
         try { compatibility.storage.setItem(PEAK_NOTIFY_KEY, String(val)) } catch (e) { /* ignore */ }
-        try { compatibility.dispatch(SETTINGS_EVENT) } catch (e) { /* ignore */ }
+        announcePrefs(false)
       }
 
       function handlePointerDown(e) {
@@ -2037,11 +2113,10 @@ window.__ModuleLoader__.load({
           if (dragRef.current.dragged) {
             var w = dragRef.current.rectWidth || (isVertical ? 140 : 180)
             var h = dragRef.current.rectHeight || (isVertical ? 120 : 60)
-            var maxX = (window.innerWidth || 1024) - w - 8
-            var maxY = (window.innerHeight || 768) - h - 8
-            var nextX = Math.max(8, Math.min(maxX, moveEvent.clientX - dragRef.current.grabOffsetX))
-            var nextY = Math.max(8, Math.min(maxY, moveEvent.clientY - dragRef.current.grabOffsetY))
-            var nextPos = { x: Math.round(nextX), y: Math.round(nextY) }
+            var nextPos = clampPeakPosition({
+              x: moveEvent.clientX - dragRef.current.grabOffsetX,
+              y: moveEvent.clientY - dragRef.current.grabOffsetY,
+            }, w, h, window.innerWidth, window.innerHeight, 8)
             latestPosRef.current = nextPos
             setPos(nextPos)
           }
@@ -2056,9 +2131,20 @@ window.__ModuleLoader__.load({
             setDragging(false)
             setDock('free')
             setPos(finalPos)
-            try { compatibility.dispatch(SETTINGS_EVENT) } catch (err) { /* ignore */ }
+            announcePrefs(false)
           }
           dragRef.current = null
+          // Release the "this was a drag, swallow the click" latch after the
+          // click that follows pointerup. Without this the flag stays true
+          // whenever the next pointerdown never arrives (pointer released
+          // outside the window, a cancelled gesture), and every later click on
+          // the card is swallowed — the control panel then refuses to open
+          // until the page is reloaded.
+          if (typeof window.setTimeout === 'function') {
+            window.setTimeout(function () { didDragRef.current = false }, 0)
+          } else {
+            didDragRef.current = false
+          }
           window.removeEventListener('pointermove', onMove)
           window.removeEventListener('pointerup', onUp)
           window.removeEventListener('pointercancel', onUp)
@@ -2076,10 +2162,10 @@ window.__ModuleLoader__.load({
         try {
           compatibility.storage.setItem(PEAK_DOCK_KEY, 'sidebar')
           compatibility.storage.removeItem(PEAK_POS_KEY)
-          compatibility.dispatch(SETTINGS_EVENT)
-          compatibility.dispatch(PEAK_RING_EVENT)
         } catch (err) { /* ignore */ }
+        announcePrefs()
       }
+
 
       var cardStyle = {}
       if (isFreeFloating) {
@@ -3853,6 +3939,7 @@ window.__ModuleLoader__.load({
       computeSnapPreview: computeSnapPreview,
       computeSideDockX: computeSideDockX,
       computePanelPosition: computePanelPosition,
+      clampPeakPosition: clampPeakPosition,
       createCompatibilityAdapter: createCompatibilityAdapter,
       fmtCurrency: fmtCurrency,
       selectBalanceInfo: selectBalanceInfo,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepseek-harness-wallet",
   "description": "Local-first account monitoring, usage accounting, official recharge, completion reminders, flexible layout, host-gated session controls, and multi-account management with hot account switching for DeepSeek Harness.",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "type": "module",
   "main": "index.js",
   "exports": {

--- a/test/wallet.test.mjs
+++ b/test/wallet.test.mjs
@@ -233,7 +233,7 @@ test('release READMEs use only approved status badges and every local Markdown t
 test('release identity and intended npm archive inventory stay aligned', () => {
   const pkg = JSON.parse(readProjectFile('package.json'))
   assert.equal(pkg.name, 'deepseek-harness-wallet')
-  assert.equal(pkg.version, '0.2.4')
+  assert.equal(pkg.version, '0.2.5')
   assert.equal(pkg.main, 'index.js')
   assert.equal(pkg.dsh.client.platform, 'web')
   assert.deepEqual(pkg.files, [
@@ -1492,7 +1492,10 @@ test('activateAccount: missing accounts and refused credential writes fail safel
   assert.equal((await mod.activateAccount(ctx, 'acc_missing')).ok, false)
   const failed = await mod.activateAccount(ctx, added.account.id)
   assert.equal(failed.ok, false)
-  assert.equal(failed.error, 'shadowed write refused')
+  // The raw provider message may name paths, env vars or key fragments: the
+  // browser must only ever see a bounded enum.
+  assert.equal(failed.error, 'credential-write-refused')
+  assert.doesNotMatch(failed.error, /shadowed write refused/, 'upstream error text must not reach the client')
   // The stored activeId is left untouched on failure.
   assert.equal(mod.activeAccount().id, added.account.id)
 })
@@ -1768,6 +1771,7 @@ test('peak ring clock registers on the sidebar footer slot, not the settings pag
   // The ring once sat inside the settings hero; that placement was wrong and
   // must stay gone.
   assert.doesNotMatch(source, /dshw_peakHero|dshw_peakRingBox|key: 'peakhero'/, 'the settings page must not embed the ring clock')
+  assert.match(source, /ReactDOM\.createPortal/, 'floating card and control panel must escape sidebar clipping through a portal')
   // Design-sheet commitments: warning/success color pair, triangle pointer,
   // zero in-ring text, an independent switch, and reminder dedup storage.
   assert.match(source, /\.dshw_ringOff\{stroke:var\(--dsw-alias-state-success-primary/, 'off-peak arcs use the success color family')
@@ -1986,7 +1990,26 @@ test('dark mode theme compliance: client css avoids un-themed hardcoded white ba
   assert.doesNotMatch(source, /--dsw-alias-bg-elevated,#fff/g, 'bg-elevated must not fallback to hardcoded light #fff')
   assert.doesNotMatch(source, /--dsw-alias-bg-overlay,#fff/g, 'bg-overlay must not fallback to hardcoded light #fff')
   assert.doesNotMatch(source, /--dsw-alias-label-quaternary,rgba\(31,35,40/g, 'quaternary label must use standard dimmed variable')
+  assert.doesNotMatch(source, /#fff(?:fff)?|#1f2328/g, 'client CSS must not carry light-theme-only hardcoded fallbacks')
   assert.match(source, /--dsw-alias-bg-layer-1/g, 'standard layer-1 bg variable is used')
+})
+
+test('floating peak card positions are clamped for saved coordinates, scale changes, and small viewports', () => {
+  const renderer = createHookRenderer()
+  const { exports } = loadClientBundle(renderer.React)
+  const clamp = exports.__testing.clampPeakPosition
+  assert.equal(typeof clamp, 'function')
+  const bottomRight = clamp({ x: 900, y: 700 }, 240, 100, 1024, 768, 8)
+  assert.equal(bottomRight.x, 776)
+  assert.equal(bottomRight.y, 660)
+  const topLeft = clamp({ x: -100, y: -40 }, 240, 100, 1024, 768, 8)
+  assert.equal(topLeft.x, 8)
+  assert.equal(topLeft.y, 8)
+  // A rendered 120% card wider than the viewport remains reachable at the
+  // safe margin instead of producing a negative max coordinate.
+  const oversized = clamp({ x: 900, y: 700 }, 1400, 900, 1024, 768, 8)
+  assert.equal(oversized.x, 8)
+  assert.equal(oversized.y, 8)
 })
 
 test('clicking peak ring footer toggles dedicated control panel with full customization choices', async () => {
@@ -2024,6 +2047,50 @@ test('clicking peak ring footer toggles dedicated control panel with full custom
   assert.ok(findElement(panel, (el) => el.props && el.props['aria-label'] === '控制面板时钟卡片比例'), 'panel exposes scale slider')
   assert.ok(findElement(panel, (el) => el.props && el.props['aria-label'] === '控制面板时钟充值按钮'), 'panel exposes recharge toggle')
   assert.ok(findElement(panel, (el) => el.props && el.props['aria-label'] === '控制面板开启峰谷切换提醒'), 'panel exposes notification toggle')
+})
+
+test('peak prefs writes suppress their own event echo', () => {
+  const source = readProjectFile('lib/client.js')
+  assert.match(source, /suppressSelfSyncRef/, 'the ring must guard against re-reading storage from its own dispatch')
+  assert.match(source, /function announcePrefs/, 'preference writes go through one announce helper')
+  assert.match(source, /if \(suppressSelfSyncRef\.current\) return/, 'the change listener skips the self echo')
+  // Every preference writer must use the guarded announce helper rather than
+  // dispatching the shared events inline; the inline form lets this component's
+  // own listener re-read storage and setState again, racing the queued write.
+  const ringBody = source.slice(source.indexOf('function PeakRingFooter'), source.indexOf('function WalletChip'))
+  const ringDispatches = ringBody.match(/compatibility\.dispatch\(PEAK_RING_EVENT\)/g) || []
+  assert.equal(ringDispatches.length, 1, 'the ring event may only be dispatched from inside announcePrefs')
+  for (const fn of ['updateOrient', 'updateScale', 'updateRecharge', 'handleResetDock']) {
+    const start = ringBody.indexOf('function ' + fn)
+    assert.ok(start >= 0, fn + ' must exist')
+    assert.match(ringBody.slice(start, start + 420), /announcePrefs\(/, fn + ' must announce through the guarded helper')
+  }
+})
+
+test('drag latch releases after pointerup so the card stays clickable', () => {
+  const source = readProjectFile('lib/client.js')
+  const ringBody = source.slice(source.indexOf('function PeakRingFooter'), source.indexOf('function WalletChip'))
+  const upStart = ringBody.indexOf('function onUp()')
+  assert.ok(upStart >= 0, 'the drag release handler must exist')
+  const upBody = ringBody.slice(upStart, upStart + 1200)
+  assert.match(upBody, /didDragRef\.current = false/, 'pointerup must clear the drag latch; otherwise a lost pointerup permanently swallows card clicks')
+})
+
+test('storage falls back to memory readably when the native write is refused', () => {
+  const renderer = createHookRenderer()
+  // A native store that accepts reads but refuses every write (private mode /
+  // quota): the adapter must serve the fallback value back, not the stale one.
+  const refusing = {
+    getItem() { return 'stale-native-value' },
+    setItem() { throw new Error('quota exceeded') },
+    removeItem() {},
+  }
+  const { exports } = loadClientBundle(renderer.React, {}, { localStorage: refusing })
+  const adapter = exports.__testing.createCompatibilityAdapter({ localStorage: refusing })
+  adapter.storage.setItem('dshw-peak-dock-v1', 'sidebar')
+  assert.equal(adapter.storage.getItem('dshw-peak-dock-v1'), 'sidebar', 'the refused write must still read back from memory')
+  adapter.storage.removeItem('dshw-peak-dock-v1')
+  assert.equal(adapter.storage.getItem('dshw-peak-dock-v1'), 'stale-native-value', 'after removal the native value is authoritative again')
 })
 
 


### PR DESCRIPTION
## 中文

发布 `deepseek-harness-wallet` v0.2.5，针对 v0.2.4 的全面检查结果进行修复。

### 修复内容

- 修复浮动峰谷卡片在窗口缩放、卡片放大、横纵排版切换或历史坐标过期后跑出视口的问题。
- 恢复 Portal 挂载，确保浮动卡片和控制面板脱离侧边栏溢出裁剪。
- 清理峰谷面板、浮动卡片、开关和按钮中的硬编码浅色背景/文字回退。
- 保留账户错误枚举、存储权限、余额刷新异常处理、偏好同步防回声和拖拽点击隔离等安全加固。
- 移除未兑现的未定价模型“下限显示”注释，避免实现与说明不一致。

### 验证

- 插件回归测试：78/78 通过
- 语法检查：通过
- 发布包检查：通过
- 本地 Harness 部署：0.2.5
- 浅色/暗色界面验证：通过
- 横向/纵向、充值开关、自由拖动、刷新持久化、归位：通过
- 控制台错误：无

## English

Release `deepseek-harness-wallet` v0.2.5 with the fixes found during the full v0.2.4 audit.

### Fixes

- Fixed floating peak-clock cards escaping the viewport after window resize, scaling, orientation changes, or stale saved coordinates.
- Restored Portal mounting so floating cards and the control panel escape sidebar overflow clipping.
- Removed hardcoded light background/text fallbacks from peak panels, floating cards, switches, and buttons.
- Retained account error enums, storage permissions, balance-refresh failure handling, preference self-echo protection, and drag/click isolation.
- Removed the unimplemented “lower bound” promise for unpriced-model display so behavior and documentation remain aligned.

### Verification

- Plugin regression tests: 78/78 passed
- Syntax checks: passed
- Publishable package check: passed
- Local Harness deployment: 0.2.5
- Light/dark UI verification: passed
- Horizontal/vertical layouts, recharge toggle, free dragging, reload persistence, and dock reset: passed
- Browser console errors: none
